### PR TITLE
Skip tech lead updates on sprint kickoff Mondays

### DIFF
--- a/events/open-standup.md
+++ b/events/open-standup.md
@@ -7,7 +7,7 @@ description: How do we do whole-team standup at Artsy?
 
 We've been doing engineering standups for as long as there has been an engineering team. The format has changed over time as the size and scope of Artsy has changed. We're now on our fourth iteration of this process.
 
-Whichever two engineers are beginning their on-call rotation are responsibile for running the standup. Pick one person to run the talking parts, and one person to take notes.
+Whichever two engineers are beginning their on-call rotation are responsible for running the standup. Pick one person to run the talking parts, and one person to take notes.
 
 ### Ten minutes before a standup
 

--- a/events/open-standup.md
+++ b/events/open-standup.md
@@ -5,31 +5,24 @@ description: How do we do whole-team standup at Artsy?
 
 # Dev Team Standup at Artsy
 
-We've been doing engineering standups for as long as there has been an engineering team. The formats have changed
-over time as the size and scope of Artsy has changed. We're now on our fourth iteration of this process.
+We've been doing engineering standups for as long as there has been an engineering team. The format has changed over time as the size and scope of Artsy has changed. We're now on our fourth iteration of this process.
 
-A standup is ideally ran by two people, one person talking, the other taking notes. Decide amongst yourselves which
-of you will do the before standup stuff.
-
-**Note**: We document our standup process to the degree that _anyone_ on our team can run the standup because we
-believe that _everyone_ should run at least one meeting. These standups are important for team cohesion and
-cross-team knowledge sharing; they are an organization-wide responsibility and every engineer should participate.
+Whichever two engineers are beginning their on-call rotation are responsibile for running the standup. Pick one person to run the talking parts, and one person to take notes.
 
 ### Ten minutes before a standup
 
-- Whichever two engineers are beginning their on-call rotation are responsibility for running the standup. Pick one
-  person to run the talking parts, and one person to take notes.
-- The person handling the talking parts `@here`s the dev channel. Include where the meeting is in the NYC office
-  (usually the Classroom).
-- The same person reminds last week's on-call staff in #dev to prepare their updates about last week's rotation.
+The person handling the talking parts does this stuff ten minutes before standup:
+
+- `@here`s the dev channel. Include where the meeting is in the NYC office (usually the Classroom).
+- Remind last week's on-call staff in #dev to prepare their updates about last week's rotation.
   Something like:
-  > @personA @personB reminder, we're looking for a list of major or notable incidents from last week during
-  > standup.
-- The same person reminds the team leads in #dev to prepare their tweet-sized updates, something like this:
-  > friendly reminder: we’re doing summary updates from tech leads during open standup, so have yours ready! /cc
-  > @tech-leads
+  > @personA @personB reminder, we're looking for a list of major or notable incidents from last week during standup.
+- On Mondays that are NOT the start of a sprint, remind the team leads in #dev to prepare their tweet-sized updates, something like this:
+  > friendly reminder: we’re doing summary updates from tech leads during open standup, so have yours ready! /cc @tech-leads
 
 ### What is a good update?
+
+On Mondays that are the start of a sprint, tech leads skip their updates as we've already heard what's going on during sprint kickoff. It's ok for a tech lead's update to consist of "everything is cool, next!" but also feel free to cover things like this:
 
 - Should focus on status of product work
 - Raises larger technical changes which affect other teams
@@ -46,8 +39,7 @@ cross-team knowledge sharing; they are an organization-wide responsibility and e
 - We have a spot to talk about things people are proud of
 - We then either announce [the Lunch & Learn][ll], or try find one for the week
 
-During the standup, someone writes up these notes and passes them out on to Slack after. Everyone leaves links to
-things they have commented on during the meeting, if they don't, we chase them up.
+These notes are then passed out on to Slack after standup. Everyone leaves links to things they have commented on during the meeting, if they don't, we chase them up.
 
 ## Our Markdown Template
 


### PR DESCRIPTION
This PR adds some advice for skipping tech lead updates on Mondays where we've done a sprint kickoff since we've already covered this stuff. I also did some random cleanup, hope that's ok! This closes https://github.com/artsy/potential/issues/170.