### PR TITLE
Applies artsy/meta#44

### DIFF
--- a/events/open-standup.md
+++ b/events/open-standup.md
@@ -84,6 +84,10 @@ _New Milestones / Repos / Blog posts_
 
 -
 
+_Current team-wide RFCs_
+
+-
+
 _Lunch & Learn_
 
 -


### PR DESCRIPTION
This PR got lost in the docs migration, looks like: https://github.com/artsy/meta/pull/44. /cc @mbilokonsky 