### PR TITLE
Adds Psychological Safety to engineering guiding principles

### DIFF
--- a/culture/engineering-principles.md
+++ b/culture/engineering-principles.md
@@ -12,8 +12,8 @@ development culture unique and drive us to do great work.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Open Source by Default](#open-source-by-default)
+- [Psychological Safety](#psychological-safety)
 - [Own Your Dependencies](#own-your-dependencies)
 - [Incremental Revolution](#incremental-revolution)
 - [Being Nice is Nice](#being-nice-is-nice)
@@ -51,6 +51,27 @@ most of our projects don’t get large enough for their stewardship to become bu
   - Artsy Blog Series - [OSS by Default](https://artsy.github.io/series/open-source-by-default/)
   - [Open Source Ideology](https://ashfurrow.com/blog/open-source-ideology/)
   - [iOS at Scale: Artsy](https://www.objc.io/issues/22-scale/artsy/)
+
+### Psychological Safety
+
+At it's core, engineering is the practice of learning. To learn effectively and to be productive, engineers
+**must** feel safe asking questions and discussing mistakes. Everyone in Artsy Engineering, but especially those in
+leadership positions, are responsible for fostering a psychologically safe work environment. Specifically, that
+means:
+
+- Admitting and discussing mistakes ("We introduced this bug, what can we learn from it?").
+- Framing work primarily as a learning experience ("Let's pair on this feature so we can learn X new framework
+  together.").
+- Demonstrating curiosity and praising curiosity in others ("(When asked a question in a DM) This is a good
+  question, would you mind asking in #channel-name so others can learn too?").
+
+- Further Reading:
+
+  - [What it Feels Like to Work in a Supportive Environment for Female Engineers](https://medium.com/artsy-blog/what-it-feels-like-to-work-in-a-supportive-environment-for-female-engineers-3c994a001007)
+  - [Building Better Software by Building Better Teams](https://ashfurrow.com/blog/building-better-software-by-building-better-teams/)
+  - [Building Compassionate Software](https://ashfurrow.com/blog/building-compassionate-software/)
+  - [High-Performing Teams Need Psychological Safety. Here’s How to Create It](https://hbr.org/2017/08/high-performing-teams-need-psychological-safety-heres-how-to-create-it)
+  - [Psychological Safety, Risk Tolerance and High Functioning Software Teams](https://hackernoon.com/psychological-safety-risk-tolerance-and-high-functioning-software-teams-75701ed23f68)
 
 ### Own Your Dependencies
 


### PR DESCRIPTION
Following [an RFC](https://github.com/artsy/potential/issues/177) discussed privately among Artsy engineers, we decided to add Psychological Safety to our list of engineering guiding principles. I added it second after "Open Source by Default" because OSS by Default is probably Artsy Engineering's defining characteristic, but Psychological Safety is critical as well (as evinced by the recent PDDE Culture ethnography, which is still a WIP).

@xtina-starr we've chatted a lot about this and I'd like to hear your feedback on the wording below. 

Fixes https://github.com/artsy/potential/issues/177.