### PR TITLE
Highlights doc for Artsy Engineering

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
     "Artsy’s",
     "Bienale",
     "Datadog",
+    "Eigen",
     "Jira",
     "Kubernetes",
     "Omakase",

--- a/culture/README.md
+++ b/culture/README.md
@@ -7,6 +7,7 @@ What makes an Engineer at Artsy succeed?
 | Doc | Overview |
 |--|--|
 | [Engineering Principles](/culture/engineering-principles.md#readme) | What are the guiding principles that got us this far |
+| [Highlights of Artsy Engineering](/culture/highlights.md#readme) | What are the PRs/releases/ideas that got us to where we are? |
 | [Communication via Slack](/culture/slack.md#readme) | How do we use use Slack at Artsy |
 | [What is Artsy?](/culture/what-is-artsy.md#readme) | An externally-aimed document on what the company does |
 <!-- end_toc -->

--- a/culture/highlights.md
+++ b/culture/highlights.md
@@ -1,0 +1,168 @@
+---
+title: Highlights of Artsy Engineering
+description: What are the PRs/releases/ideas that got us to where we are?
+---
+
+# Highlights
+
+This is very much a living document, and likely missing things. so, please send PRs adding new (or old) events.
+
+- Jan 2011 - Artsy's API: Gravity is [`git init`][grav_init]'d 🔒
+- Oct 2012 - Artsy launches to [the public][nyt]
+- Jan 2012 - ["Hello World"][blog], we start off the Artsy blog
+- Feb 2012 - We move to [401 Broadway][401] 🔒
+- Feb 2012 - Artsy's partner portfolio app: Energy [is released][energy_1] 🔒 to the App Store
+- Sep 2012 - The first ["Artsy Tech Stack"][ts1] post, [series][tech-series]
+- Nov 2012 - Artsy's iOS app: Eigen is [`git init`][eigen_init]d 🔒
+- Jan 2013 - `art.sy` [->][art_sy] 🔒 `artsy.net`
+- Jul 2013 - Artsy's mobile website: Microgravity [is started][micro-start] 🔒
+- Aug 2013 - Started [modeling Auctions data][auctions-model] 🔒
+- Aug 2013 - Gravity moves [to OpsWorks][opsworks]
+- Sep 2013 - Eigen is released to the App Store
+- Oct 2013 - Artsy's first [benefit auction][auction_benefit] is launched
+- Nov 2013 - Artsy's Website: Force [is started][force-start] 🔒
+- Nov 2013 - Force starts receiving [network requests][force-network] 🔒
+- Jan 2014 - Artsy ships its first annual review - [site][2013_site] | [code][2013_code]
+- Jan 2014 - Artsy's partner CMS: Volt is [is started][volt-start] 🔒
+- Feb 2014 - [Artworks][grav_artworks] 🔒, [Genes and tags][grav_tags] 🔒, [Shows and Orders][grav_shows] 🔒 are
+  removed from Gravity
+- Mar 2014 - Fairs were re-designed in Eigen/Force, [monoliths][monoliths] were created for [Armory 2014][arm] -
+  [press][arm-pr]
+- Apr 2014 - Our first write-up [on using React][helix-react]
+- Jul 2014 - [API v2 started][v2] 🔒
+- Aug 2014 - [Force has a public fork][force_pub], making it the first open source front-end app
+- Aug 2014 - Work starts [on Eidolon][eidolon], the first OSS by Default iOS app
+- Aug 2014 - [API v2 announced][v2_announce] publicly
+- Sep 2014 - Artsy's editorial API and CMS: Positron [is created][positron]
+- Jan 2015 - Eigen [turns OSS by Default][oss_eigen]
+- May 2015 - [Posts are removed][remove_posts] 🔒 from Gravity, in favour of Positron
+- Mar 2015 - The iOS team write about OSS team culture [in objc.io][objcio]
+- Mar 2015 - Artsy [starts][peerlab-start] hosting a [peer lab][peer] every saturday morning
+- May 2015 - Artsy's initial team documentation repo: Potential [is created][pot_init] 🔒
+- Apr 2015 - Auctions are [re-created][auctions-2] for our first auction with Sotheby's
+- Jul 2015 - Eigen becomes the [center of all docs][eigen_dym] on slow launch speeds in iOS apps using Swift
+- Jul 2015 - Engineering re-orgs into practices: Platform, Web & Mobile
+- Aug 2015 - [Team Navigator v1][team_1] starts out as a hackathon project
+- Aug 2015 - Energy [becomes OSS by Default][energy_oss], moving all of the iOS projects to be OSS
+- Sep 2015 - Artsy's mobile website is used in Apple marketing
+  <a href=" https://twitter.com/dblockdotorg/status/641697132639072257"><img src="https://user-images.githubusercontent.com/49038/39097791-55938788-4659-11e8-8f73-53c3480bfb15.png" height=12></a>
+- Sep 2015 - Artsy's auction live bidding engine: Causality [is started][caus_init]
+- Oct 2015 - Artsy ships a tvOS app to the App Store
+  <a href=" https://twitter.com/dblockdotorg/status/657267075979812865"><img src="https://user-images.githubusercontent.com/49038/39097791-55938788-4659-11e8-8f73-53c3480bfb15.png" height=12></a>
+  | [code][emerge]
+- Nov 2015 - Artsy's GraphQL API gateway: Metaphysics [is created][mp]
+- Jan 2016 - Engineering [teaches Swift][teach-swift] to non-technical + technical colleagues
+- Jan 2016 - Danger is [added to Eigen][danger]
+- Feb 2016 - Artsy's React Native component library: Emission [is created][emission_init]
+- Feb 2016 - Gravity moves [to Puma][puma] 🔒
+- Mar 2016 - Engineering re-orgs into Auctions, Collector Experience & GMV, Partner Success & Revenue, Publishing
+  and Platform - [email][reorg2] 🔒
+- May 2016 - Emission is [used in Eigen][emission]
+- Jun 2016 - First live auction [in production][auction-pr] with Eigen, Force, Prediction and Causality
+  <a href=" https://twitter.com/dblockdotorg/status/747786883913101316"><img src="https://user-images.githubusercontent.com/49038/39097791-55938788-4659-11e8-8f73-53c3480bfb15.png" height=12></a>
+- Jun 2016 - Artsy gets its first queuing system [with Kafka][kafka] 🔒
+- Aug 2016 - Force is made [OSS by Default][force-oss] - moving all front-end code to be OSS.
+- Oct 2016 - Gravity's auth tokens turn [into JWTs][jwts] 🔒 - [post][jwt-blog]
+- Feb 2017 - Artsy's consignments app: Convection [is created][conv]
+- Feb 2017 - Artsy's web react components library: Reaction [is created][reaction_init]
+- Feb 2017 - Microgravity and Force [are merged][micro-end], now there is only one website
+- Feb 2017 - [Team Navigator v2][team_2] is shipped
+- Mar 2017 - React first makes its way [into Force][react-force]
+- May 2017 - Emission gets demo’d during the Microsoft Build conference’s ["What’s New in TypeScript?"][new-in-ts]
+- Jun 2017 - Peril added [to the Artsy org][peril]
+- Sep 2017 - [Force is modernized][mod_force] with the Omakase
+- Sep 2017 - Artsy has a town hall on API designs, and projects migrate to GraphQL
+- Aug 2017 - Force has its first Reaction-driven page [set up for Articles][articles]
+- Aug 2017 - Engineering does [a DevSwap][devswap]
+- Dec 2017 - Engineering re-orgs to be project and goal driven sprints
+- Jan 2018 - The [RFC process][rfc] is established
+- Jan 2018 - Engineering merges with Design and Analytics (data) and a new Product org is created, making PDDE
+- Jan 2018 - Engineering re-orgs to Grow, Discover, Evaluate, Sell and Platform
+- May 2018 - [On-call process][on-call] is formalized
+- May 2018 - Our team stand-up is automated [completely by documentation][standup]
+- Mar 2018 - Eigen becomes one of the first apps using [static frameworks][stat_frm]
+- Jun 2018 - Artsy's design system: Palette [is created][pal]
+- Jun 2018 - Artsy runs a series of workshops on the Omakase [called JavaScriptures][jss]
+- Jul 2018 - Artsy runs a conference with Facebook: [Artsy x React Native][axrn]
+- Aug 2018 - Engineering's engineering principles doc [is created][principles]
+- Aug 2018 - Artsy's public docs repo [is created][readme_init] - [RFC][docs_rfc] 🔒
+- Sep 2018 - The Artsy Omakase's name [is decided][oma_rfc]
+
+<!-- prettier-ignore-start -->
+[helix-react]: http://artsy.github.io/blog/2015/04/08/creating-a-dynamic-single-page-app-for-our-genome-team-using-react/
+[new-in-ts]: https://blogs.msdn.microsoft.com/typescript/2017/05/19/new-typescript-quick-starts-and-updates-from-build-2017/
+[reorg2]: https://groups.google.com/a/artsymail.com/forum/#!msg/team/hwLvMwuBmJo/8xGcssucBwAJ;context-place=msg/team/tHZ_lfJQH9Y/cQQKlwIcCwAJ
+<!-- prettier-ignore-end -->
+
+[blog]: http://artsy.github.io/blog/2012/01/05/hello-world/
+[grav_init]: https://github.com/artsy/gravity/commit/b289057506942a77d89ee1b619221e60cd17aaae
+[401]: https://github.com/artsy/gravity/pull/1729
+[auctions-model]: https://github.com/artsy/gravity/pull/6231
+[force-network]: https://github.com/artsy/gravity/pull/6886
+[v2]: https://github.com/artsy/gravity/pull/7862
+[ts1]: http://artsy.github.io/blog/2012/10/10/artsy-technology-stack/
+[force_pub]: http://artsy.github.io/blog/2014/09/05/we-open-sourced-our-isomorphic-javascript-website/
+[v2_announce]: http://artsy.github.io/blog/2014/09/12/designing-the-public-artsy-api/
+[eidolon]: http://artsy.github.io/blog/2014/11/13/eidolon-retrospective/
+[eigen_init]: https://github.com/artsy/eigen-private/commit/288a90
+[energy_1]: https://github.com/artsy/energy-private/releases/tag/v1.0
+[force-start]: https://github.com/artsy/force-private/pull/1
+[pot_init]: https://github.com/artsy/potential/pull/1
+[readme_init]: https://github.com/artsy/readme/pull/1
+[conv]: https://github.com/artsy/convection/pull/1
+[reaction_init]: https://github.com/artsy/reaction/commit/a2a0af
+[2013_site]: http://2013.artsy.net
+[2013_code]: https://github.com/artsy/artsy-2013
+[emission_init]: https://github.com/artsy/eigen/pull/1532
+[emission]: https://github.com/artsy/eigen/pull/1532
+[emerge]: https://github.com/artsy/emergence#readme
+[volt-start]: https://github.com/artsy/volt/pull/1
+[micro-start]: https://github.com/artsy/microgravity-private/pull/1
+[micro-end]: https://github.com/artsy/force/pull/890
+[peril]: https://github.com/artsy/reaction/pull/184
+[danger]: https://github.com/artsy/eigen/pull/1013
+[art_sy]: https://github.com/artsy/gravity/pull/4222
+[jwts]: https://github.com/artsy/gravity/pull/10495
+[puma]: https://github.com/artsy/gravity/pull/9751
+[team_1]: https://github.com/artsy/team-navigator/tree/dev
+[team_2]: https://github.com/artsy/team-navigator/
+[principles]: https://github.com/artsy/README/blob/master/culture/engineering-principles.md
+[mod_force]: https://github.com/artsy/README/blob/master/culture/engineering-principles.md
+[axrn]: http://artsy.net/x-react-native
+[eigen_dym]: https://github.com/artsy/eigen/issues/586
+[stat_frm]: https://github.com/artsy/eigen/pull/2561
+[kafka]: https://github.com/artsy/gravity/pull/10020
+[docs_rfc]: https://github.com/artsy/potential/issues/166
+[pal]: https://github.com/artsy/palette/pull/1/files
+[rfc]: https://github.com/artsy/guides/pull/4
+[oma_rfc]: https://github.com/artsy/README/issues/10
+[oss_eigen]: http://artsy.github.io/blog/2015/04/28/how-we-open-sourced-eigen/
+[jss]: http://artsy.github.io/series/javascriptures/
+[on-call]: http://artsy.github.io/blog/2018/05/25/support-process/
+[arm]: https://www.artsy.net/the-armory-show-2014
+[mp]: https://github.com/artsy/metaphysics/commit/50b23f
+[positron]: https://github.com/artsy/positron/commit/d17256
+[monoliths]: https://github.com/artsy/europa
+[react-force]: https://github.com/artsy/force/pull/1084
+[articles]: https://github.com/artsy/force/pull/1713
+[opsworks]: http://artsy.github.io/blog/2013/08/27/introduction-to-aws-opsworks/
+[devswap]: http://artsy.github.io/blog/2017/09/11/DevSwap/
+[force-oss]: http://artsy.github.io/blog/2016/09/06/Milestone-on-OSS-by-Default/
+[nyt]: https://www.nytimes.com/2012/10/09/arts/design/artsy-is-mapping-the-world-of-art-on-the-web.html
+[energy_oss]: http://artsy.github.io/blog/2015/08/06/open-sourcing-energy/
+[caus_init]: https://github.com/artsy/causality/commit/0b9f95f
+[objcio]: https://www.objc.io/issues/22-scale/
+[teach-swift]: http://artsy.github.io/blog/2016/01/26/swift-at-artsy/
+[jwt-blog]: http://artsy.github.io/blog/2016/10/26/jwt-artsy-journey/
+[standup]: http://artsy.github.io/blog/2018/05/07/fully-automated-standups/
+[peerlab-start]: https://www.meetup.com/CocoaPods-NYC/events/nrjxflytfbkb/
+[peer]: https://www.meetup.com/CocoaPods-NYC/
+[tech-series]: http://artsy.github.io/series/artsy-tech-stack/
+[arm-pr]: http://files.artsy.net/the-armory-show-2014/press-release
+[auction_benefit]: https://www.artsy.net/auction/ici-benefit-auction-2013
+[auctions-2]: https://github.com/artsy/force-private/pull/2421
+[remove_posts]: https://github.com/artsy/gravity/pull/8885
+[grav_artworks]: https://github.com/artsy/gravity/pull/7302
+[grav_genes]: https://github.com/artsy/gravity/pull/7301
+[grav_shows]: https://github.com/artsy/gravity/pull/7148
+[auction-pr]: http://files.artsy.net/documents/live-auction-integration.pdf

--- a/culture/what-is-artsy.md
+++ b/culture/what-is-artsy.md
@@ -112,6 +112,15 @@ From
 > (if anything,
 > [watch this amazing video](https://www.artsy.net/article/artsy-editorial-behind-the-venice-biennale-2015-a-short-history-of-the-world-s-most-important-art-exhibition)).
 
+### How does the Engineering team work?
+
+We've documented what we consider to be our
+[Engineering principles](https://github.com/artsy/README/blob/master/culture/engineering-principles.md), which help
+differentiate our team from other Engineering orgs.
+
+If you're interested in what we've got up to since 2011? Check out the
+[highlights](https://github.com/artsy/README/blob/master/culture/highlights.md).
+
 ### How/why do you produce so much OSS?
 
 We bake it into our engineering team culture. I'll quote the


### PR DESCRIPTION
I'd like to do something similar to what I do [for Peril](https://github.com/danger/peril/issues/235) <a href="https://twitter.com/orta/status/1041421215431385089"><img src="https://user-images.githubusercontent.com/49038/39097791-55938788-4659-11e8-8f73-53c3480bfb15.png" height=12></a> , but for Artsy.

So if you have ideas for things, either let me know in an upcoming slack thread - or push some changes to this branch