### PR TITLE
Remove team lead updates

### DIFF
--- a/events/open-standup.md
+++ b/events/open-standup.md
@@ -19,20 +19,6 @@ The person handling the talking parts does this stuff ten minutes before standup
 - Remind last week's on-call staff in #dev to prepare their updates about last week's rotation. Something like:
   > @personA @personB reminder, we're looking for a list of major or notable incidents from last week during
   > standup.
-- On Mondays that are NOT the start of a sprint, remind the team leads in #dev to prepare their tweet-sized
-  updates, something like this:
-  > friendly reminder: we’re doing summary updates from tech leads during open standup, so have yours ready! /cc
-  > @tech-leads
-
-### What is a good update?
-
-On Mondays that are the start of a sprint, tech leads skip their updates as we've already heard what's going on
-during sprint kickoff. It's ok for a tech lead's update to consist of "everything is cool, next!" but also feel
-free to cover things like this:
-
-- Should focus on status of product work
-- Raises larger technical changes which affect other teams
-- Talks about the team effort rather than an individual's work
 
 ### During standup
 
@@ -41,7 +27,6 @@ free to cover things like this:
 - Then we get an update from the CTO
 - Then an update from the Product team (someone should be present to give one)
 - Then an update from last week's on-call support team, including follow-up work items
-- Each tech lead gives a summary of what their teams have been up to
 - We leave a spot for potential cross-team issues
 - We have a spot to talk about things people are proud of
 - We then either announce [the Lunch & Learn][ll], or try find one for the week
@@ -68,14 +53,6 @@ _On-call Support Updates_
 
 - This week, @personC and @personD will be on-call for support.
 - ## Last week, we saw the following notable incidents (please include follow-up details)
-
-_Team Updates_ (optional)
-
-- Grow:
-- DiscoValuate:
-- Purchase:
-- Sell:
-- Platform:
 
 _Cross-dependencies / Requests for Pairing_
 


### PR DESCRIPTION
Per [this RFC](https://github.com/artsy/README/issues/56), I'm yanking the team lead updates from our open standup.

Closes #61 