### PR TITLE
@ashleyjelks: Try to document how we use Jira boards and issues

### DIFF
--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -26,6 +26,7 @@ practice should be incorporated, submit a PR!
 | [GraphQL Schema Design](/playbooks/graphql-schema-design.md#readme) | What are our best practices for GraphQL Schema Design? |
 | [Hokusai](/playbooks/hokusai.md#readme) | a CLI to manage applications deployed to Kubernetes |
 | [How to give a good Informational](/playbooks/informationals.md#readme) | What are the steps needed to give someone a great experience. |
+| [Jira](/playbooks/jira.md#readme) | Working with Jira boards and tickets |
 | [Kubernetes](/playbooks/kubernetes.md#readme) | Deploying containerized applications at Artsy |
 | [How to run a retrospective](/playbooks/retrospectives.md#readme) | The why and how for running a retrospective |
 | [How to create an RFC at Artsy](/playbooks/rfcs.md#readme) | The steps needed to request cultural changes |

--- a/playbooks/jira.md
+++ b/playbooks/jira.md
@@ -1,0 +1,31 @@
+---
+title: Jira
+description: Working with Jira boards and tickets
+---
+
+# Jira
+
+We use [Jira](https://artsyproduct.atlassian.net/) as a common tool for managing product work. Each team works
+within a "project."
+
+## Kanban stages/columns
+
+Our workflow takes Jira issues through these stages:
+
+| Name:     | Define                                                                      | Ready                                                                                    | In Progress              | Review                                                | Merged                                       | Monitoring             | Done                                                                                                                        |
+| --------- | --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------ | ----------------------------------------------------- | -------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Criteria: | Further definition or requirements needed before engineering work can begin | Requirements, priority, and high-level design are established enough that work can begin | Actively being developed | Pull request submitted and being reviewed or improved | Merged and deployed to staging; ready for QA | Deployed to production | Confirmed to work as expected in production; any data has been collected; clean-up complete (no further tracking necessary) |
+
+## Types of Jira issues
+
+- **Epics** should be _goal_ oriented
+- **Stories** should be _impact_ oriented
+- **Subtasks** (when necessary) should be _release_ oriented, usually corresponding to pull requests
+
+## Sprints
+
+(TO DO)
+
+## Estimation
+
+(JK)


### PR DESCRIPTION
Now that we've repeated the explanation of how we use Jira boards and issues a few times, it might be time to document it. Interested to hear if this is helpful, or any other feedback.

Big caveat: I recognize that these board columns are not _completely_ standardized across teams. In particular, Platform and Purchase teams use these but other teams collapse the "monitoring" stage into either "merged"/QA or just skip it to "done." I would make a strong argument to these teams to recognize the stage at which code must be released to production, but data-collection, confirmation, or clean-up is still pending. I think we encounter this gap often in practice (e.g., we've merged something but not ensured it's in production, or released something but not confirmed it does what's expected). This document reflects my _recommendation_.