### PR TITLE
Add link for instructions on getting an AWS account created.

### DIFF
--- a/.github/ISSUE_TEMPLATE/engineering-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/engineering-onboarding.md
@@ -53,7 +53,7 @@ _Remember to review *all* setup scripts before executing them :)_
 - [ ] Keep your eye out for ways to improve our documentation-- including in this repo! A code change is great, but
       improving documentation (in _whatever_ little way) with your fresh set of eyes helps us help the next person
       onboarding. We emphatically do not underestimate it, this is _real_ work!
-- [ ] Ask an engineer for help getting set up with an AWS account.
+- [ ] Ask an engineer for help getting set up with an AWS account. They can find instructions on creating your account [here](https://github.com/artsy/potential/wiki/Platform-FAQ#add-a-new-aws-user).
 - [ ] Follow the instructions in https://github.com/artsy/hokusai to get set up with hokusai.
 - [ ] Successfully open a gravity staging and production console
 


### PR DESCRIPTION
@jonallured helped me create an AWS account, and referenced some instructions on how he did it. It'd be useful to have that link in here, in case someone doesn't know where to find it.