### PR TITLE
Update Running Lunch & Learn instructions

### DIFF
--- a/playbooks/running-lunch-and-learn.md
+++ b/playbooks/running-lunch-and-learn.md
@@ -79,7 +79,7 @@ Move the card to the "Done" column. Nice work!
 
 ##### Connecting to the screen
 
-- For Artsy staff, they should be on the staff WIFI and connect via Air Display to "27 - Classroom"
+- For Artsy staff, they should be on the staff WIFI and connect via AirPlay to "27 - Classroom"
 - For external folk:
   - They can join the zoom url, you can get this emailed from the iPad to that person
   - You can run their slides on your computer

--- a/playbooks/running-lunch-and-learn.md
+++ b/playbooks/running-lunch-and-learn.md
@@ -81,7 +81,9 @@ Move the card to the "Done" column. Nice work!
 
 - For Artsy staff, they should be on the staff WIFI and connect via AirPlay to "27 - Classroom"
 - For external folk:
-  - They can join the zoom url, you can get this emailed from the iPad to that person
+  - They can join the zoom url
+    [https://zoom.us/my/artsyclassroom](https://zoom.us/my/artsyclassroom). You
+    can also email the zoom URL to the speaker from the iPad.
   - You can run their slides on your computer
   
 ##### The zoom isn't available


### PR DESCRIPTION
A couple small updates to the running Lunch & Learn instructions:

- Include Artsy Classroom zoom room permalink
- Rephrase "via Air Display" to "via AirPlay"