### PR TITLE
Add padlock icon next to any link leading to private resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Welcome to Artsy! If you're a new team member, we're excited to have you! Here a
 
 This repo is a work in progress. In fact, your first pull request could be to fix or add to
 [this doc](https://github.com/artsy/README/blob/master/README.md). Reach out to your mentor or anyone else on the
-engineering team with questions, or try the [#dev Slack channel](https://artsy.slack.com/messages/dev).
+engineering team with questions, or try the [#dev Slack channel](https://artsy.slack.com/messages/dev) 🔒.
 
 Whether you're seasoned or fresh out of school, take a moment to read
 [Your First 60 Days at an Engineering Job](http://code.dblock.org/2015/04/23/your-first-60-days-at-an-engineering-job.html).
@@ -40,20 +40,20 @@ Engineers typically work on a product team and may also belong to an _Engineerin
 - Platform Practice
 
   - Team lead: [Joey](https://github.com/joeyAghion) [joey.aghion.com](http://joey.aghion.com)
-  - Slack: [#product-platform](https://artsy.slack.com/messages/product-platform)
+  - Slack: [#product-platform](https://artsy.slack.com/messages/product-platform) 🔒
   - [Platform Practice Overview](practices/platform.md)
 
 - Front-end Practice
 
   - Team lead: [Orta](https://github.com/orta) [orta.io](http://orta.io)
-  - Slack: [#front-end](https://artsy.slack.com/messages/front-end),
-    [#front-end-ios](https://artsy.slack.com/messages/front-end-ios)
+  - Slack: [#front-end](https://artsy.slack.com/messages/front-end) 🔒,
+    [#front-end-ios](https://artsy.slack.com/messages/front-end-ios) 🔒
   - [Front-end Practice Overview](practices/front-end.md)
 
 ## Support
 
 If you are on call or asked to fix an immediate issue, check out our doc on
-[how support works](/playbooks/support#readme) and reference our
-[support wiki 🔑](https://github.com/artsy/potential/wiki) for up-to-date playbooks on how to solve issues.
+[how support works](/playbooks/support.md#readme) and reference our
+[support wiki](https://github.com/artsy/potential/wiki) 🔒 for up-to-date playbooks on how to solve issues.
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" />

--- a/culture/slack.md
+++ b/culture/slack.md
@@ -5,7 +5,7 @@ description: How we use use Slack at Artsy
 
 # Slack
 
-Get on [Slack](https://artsy.slack.com). You can download the OS X app from the
+Get on [Slack](https://artsy.slack.com) 🔒. You can download the OS X app from the
 [Apple store](https://itunes.apple.com/us/app/slack/id803453959?mt=12). Also, install it on your phone. We use
 Slack for all internal messaging, and prefer it to email in, basically, all cases.
 
@@ -13,61 +13,61 @@ Slack for all internal messaging, and prefer it to email in, basically, all case
 
 You should always feel up to date on these two:
 
-- [#dev](https://artsy.slack.com/messages/dev): Engineering-wide chat.
-- [#dev-offtopic](https://artsy.slack.com/messages/dev-offtopic): Engineers chatting about less timely and
+- [#dev](https://artsy.slack.com/messages/dev) 🔒: Engineering-wide chat.
+- [#dev-offtopic](https://artsy.slack.com/messages/dev-offtopic) 🔒: Engineers chatting about less timely and
   work-relevant topics.
 
 There are a few other useful dev-related slacks:
 
-- [#dev-banter](https://artsy.slack.com/messages/dev-banter): For chatting with developers, not about work.
-- [#dev-candidates](https://artsy.slack.com/messages/dev-candidates): If you want to be involved in hiring.
+- [#dev-banter](https://artsy.slack.com/messages/dev-banter) 🔒: For chatting with developers, not about work.
+- [#dev-candidates](https://artsy.slack.com/messages/dev-candidates) 🔒: If you want to be involved in hiring.
 
 Engineering teams each maintain a dedicated channel (but all are welcome):
 
-- Grow: [#product-grow](https://artsy.slack.com/messages/product-grow)
-- Discover/Evaluate: [#product-discovaluate](https://artsy.slack.com/messages/product-discovaluate)
-- Purchase: [#product-purchase](https://artsy.slack.com/messages/product-purchase)
-- Sell: [#product-sell](https://artsy.slack.com/messages/product-sell)
-- Platform: [#product-platform](https://artsy.slack.com/messages/product-platform)
+- Grow: [#product-grow](https://artsy.slack.com/messages/product-grow) 🔒
+- Discover/Evaluate: [#product-discovaluate](https://artsy.slack.com/messages/product-discovaluate) 🔒
+- Purchase: [#product-purchase](https://artsy.slack.com/messages/product-purchase) 🔒
+- Sell: [#product-sell](https://artsy.slack.com/messages/product-sell) 🔒
+- Platform: [#product-platform](https://artsy.slack.com/messages/product-platform) 🔒
 
 Some other channels engineers might find helpful:
 
-- [#data](https://artsy.slack.com/messages/data)
-- [#front-end](https://artsy.slack.com/messages/front-end)
-- [#front-end-ios](https://artsy.slack.com/messages/front-end-ios)
-- [#global](https://artsy.slack.com/messages/global)
-- [#graphql](https://artsy.slack.com/messages/graphql)
-- [#onboarding-eng](https://artsy.slack.com/messages/onboarding-eng)
-- [#product](https://artsy.slack.com/messages/product)
-- [#deployments](https://artsy.slack.com/messages/deployments)
-- [#peopleops](https://artsy.slack.com/messages/peopleops)
-- [#workplace](https://artsy.slack.com/messages/workplace)
+- [#data](https://artsy.slack.com/messages/data) 🔒
+- [#front-end](https://artsy.slack.com/messages/front-end) 🔒
+- [#front-end-ios](https://artsy.slack.com/messages/front-end-ios) 🔒
+- [#global](https://artsy.slack.com/messages/global) 🔒
+- [#graphql](https://artsy.slack.com/messages/graphql) 🔒
+- [#onboarding-eng](https://artsy.slack.com/messages/onboarding-eng) 🔒
+- [#product](https://artsy.slack.com/messages/product) 🔒
+- [#deployments](https://artsy.slack.com/messages/deployments) 🔒
+- [#peopleops](https://artsy.slack.com/messages/peopleops) 🔒
+- [#workplace](https://artsy.slack.com/messages/workplace) 🔒
 
 There are _many_ other topic-specific channels. You'll find these out organically. Here is a sample list of
-interesting, [banter-y Slack channels](https://artsy.slack.com/archives/C02531TUD/p1533749286000516) you might want
+interesting, [banter-y Slack channels](https://artsy.slack.com/archives/C02531TUD/p1533749286000516) 🔒 you might want
 to check out:
 
-- [#cabort-bookclub](https://artsy.slack.com/messages/cabort-bookclub) is a sci-fi book club
-- [#video-games](https://artsy.slack.com/messages/video-games) for video games
-- [#cats](https://artsy.slack.com/messages/cats) for cat-lovers
-- [#dogs](https://artsy.slack.com/messages/dogs) for dog-lovers
-- [#teamcanada](https://artsy.slack.com/messages/teamcanada) for Canadians and Canadian-adjacent people
-- [#hotpot](https://artsy.slack.com/messages/hotpot) for organizing hotpot dinners in Chinatown, next door to the
+- [#cabort-bookclub](https://artsy.slack.com/messages/cabort-bookclub) 🔒 is a sci-fi book club
+- [#video-games](https://artsy.slack.com/messages/video-games) 🔒 for video games
+- [#cats](https://artsy.slack.com/messages/cats) 🔒 for cat-lovers
+- [#dogs](https://artsy.slack.com/messages/dogs) 🔒 for dog-lovers
+- [#teamcanada](https://artsy.slack.com/messages/teamcanada) 🔒 for Canadians and Canadian-adjacent people
+- [#hotpot](https://artsy.slack.com/messages/hotpot) 🔒 for organizing hotpot dinners in Chinatown, next door to the
   office
-- [#vr](https://artsy.slack.com/messages/vr) for virtual reality
-- [#aotd](https://artsy.slack.com/messages/aotd) is "Artwork of the Day", a good place to chat about art
-- [#extreme-bevvies](https://artsy.slack.com/messages/extreme-bevvies) is for extreme beverages (started with
+- [#vr](https://artsy.slack.com/messages/vr) 🔒 for virtual reality
+- [#aotd](https://artsy.slack.com/messages/aotd) 🔒 is "Artwork of the Day", a good place to chat about art
+- [#extreme-bevvies](https://artsy.slack.com/messages/extreme-bevvies) 🔒 is for extreme beverages (started with
   Soylent but has evolved a lot since)
-- [#house-plants](https://artsy.slack.com/messages/house-plants) for house plants (conversations, questions, asking
+- [#house-plants](https://artsy.slack.com/messages/house-plants) 🔒 for house plants (conversations, questions, asking
   for help)
-- [#karaoke](https://artsy.slack.com/messages/karaoke) for organizing karaoke outings
-- [#samplesales](https://artsy.slack.com/messages/sameplsales) to coordinate around sample sales, a staple of NYC
+- [#karaoke](https://artsy.slack.com/messages/karaoke) 🔒 for organizing karaoke outings
+- [#samplesales](https://artsy.slack.com/messages/sameplsales) 🔒 to coordinate around sample sales, a staple of NYC
   and of Tribeca particularly
-- [#android](https://artsy.slack.com/messages/android) for Android-lovers
-- [#anime](https://artsy.slack.com/messages/anime) for anime-lovers
-- [#yelling](https://artsy.slack.com/messages/yelling) is a CAPS-ONLY channel
-- [#coffeetalk](https://artsy.slack.com/messages/coffeetalk) for chat about coffee
-- [#jam-session](https://artsy.slack.com/messages/jam-session) for musicians at Artsy to plan monthly after-work
+- [#android](https://artsy.slack.com/messages/android) 🔒 for Android-lovers
+- [#anime](https://artsy.slack.com/messages/anime) 🔒 for anime-lovers
+- [#yelling](https://artsy.slack.com/messages/yelling) 🔒 is a CAPS-ONLY channel
+- [#coffeetalk](https://artsy.slack.com/messages/coffeetalk) 🔒 for chat about coffee
+- [#jam-session](https://artsy.slack.com/messages/jam-session) 🔒 for musicians at Artsy to plan monthly after-work
   jam-sessions
 
 ### Tips and Tricks

--- a/onboarding/engineering-introduction.md
+++ b/onboarding/engineering-introduction.md
@@ -38,7 +38,7 @@ The standup is fully documented [here](/events/open-standup.md).
 ### Getting Help
 
 - **Slack:** If you know what team could potentially help you, browse the channels in Slack to find the most
-  relevant place to ask your question. If you aren't sure, [#dev](https://artsy.slack.com/messages/dev) is a good
+  relevant place to ask your question. If you aren't sure, [#dev](https://artsy.slack.com/messages/dev) 🔒 is a good
   place to start.
 - **Ask Your Neighbor:** Everyone is friendly. Don't hesitate to reach out to the people around you for even the
   most basic of questions.
@@ -69,23 +69,23 @@ Orta also wrote a blog post on the
 
 ### GitHub
 
-Artsy stores source code on [GitHub](https://github.com/artsy). Make sure you have an account and are part of the Artsy organization. If you can't visit [this page](https://github.com/artsy/gravity), then you don’t have the right access. Your mentor can get you sorted out.
+Artsy stores source code on [GitHub](https://github.com/artsy). Make sure you have an account and are part of the Artsy organization. If you can't visit [this page](https://github.com/artsy/gravity) 🔒, then you don’t have the right access. Your mentor can get you sorted out.
 
-Our projects use physics terms as code names, starting with [Gravity](https://github.com/artsy/gravity) (inspired
+Our projects use physics terms as code names, starting with [Gravity](https://github.com/artsy/gravity) 🔒 (inspired
 by [Zachary Coffin's "Temple of Gravity"](http://www.zacharycoffin.com/work/temple-of-gravity)).
 
-See the [engineering projects map](https://github.com/artsy/potential/wiki/Project-List) for a comprehensive list of our (many) repos and who owns them. It can be a bit overwhelming, so here are some important ones:
+See the [engineering projects map](https://github.com/artsy/potential/wiki/Project-List) 🔒 for a comprehensive list of our (many) repos and who owns them. It can be a bit overwhelming, so here are some important ones:
 
-- [Gravity](https://github.com/artsy/gravity): Artsy's main API
+- [Gravity](https://github.com/artsy/gravity) 🔒: Artsy's main API
 - [Force](https://github.com/artsy/force): Artsy web site ([www.artsy.net](https://www.artsy.net))
 - [Eigen](https://github.com/artsy/eigen): iOS app
-- [Volt](https://github.com/artsy/volt): Content Management system for partners
+- [Volt](https://github.com/artsy/volt) 🔒: Content Management system for partners
 
 ### AWS
 
 Many applications depend on Amazon Web Services. Your mentor or anyone else in Engineering can set you up with an
 IAM profile within our organization's account (see
-[instructions](https://github.com/artsy/potential/wiki/Platform-FAQ#add-a-new-aws-user)).
+[instructions](https://github.com/artsy/potential/wiki/Platform-FAQ#add-a-new-aws-user) 🔒).
 
 ### Artsy's Stack(s)
 
@@ -97,11 +97,11 @@ which evolved from a Rails monolith.
 
 ### Artsy APIs
 
-See [apis](https://github.com/artsy/potential/blob/master/apis/README.md) in Potential.
+See [apis](https://github.com/artsy/potential/blob/master/apis/README.md) 🔒 in Potential.
 
 ### Artsy Data
 
-See [data](https://github.com/artsy/potential/blob/master/data/README.md).
+See [data](https://github.com/artsy/potential/blob/master/data/README.md) 🔒.
 
 ## How We Work
 
@@ -109,11 +109,11 @@ The engineering team [playbooks](/playbooks#readme) discuss why we make the tech
 
 ### Development Environments
 
-The [scripts/setup](https://github.com/artsy/potential/blob/master/scripts/setup) script will install common
+The [scripts/setup](https://github.com/artsy/potential/blob/master/scripts/setup) 🔒 script will install common
 dependencies for local development (homebrew, Ruby, etc.).
 
 Projects can provide their own setup scripts that build on this common foundation. See
-[Gravity's script/setup](https://github.com/artsy/gravity/blob/master/script/setup) as an example.
+[Gravity's script/setup](https://github.com/artsy/gravity/blob/master/script/setup) 🔒 as an example.
 
 ### Text Editor
 
@@ -138,7 +138,7 @@ As all of our code is housed on GitHub, we make contributions through
 [pull requests](http://artsy.github.io/blog/2012/01/29/how-art-dot-sy-uses-github-to-build-art-dot-sy/).
 
 Read more in [the engineer workflow playbook](/playbooks/engineer-workflow.md#readme) or see this
-[step-by-step guide](https://github.com/artsy/potential/blob/master/github/workflow.md). If you're unfamiliar with
+[step-by-step guide](https://github.com/artsy/potential/blob/master/github/workflow.md) 🔒. If you're unfamiliar with
 Git, check out this [short tutorial](https://try.github.io) on basic git commands (such as `git status`,
 `git commit`, and `git push`).
 

--- a/onboarding/managers.md
+++ b/onboarding/managers.md
@@ -19,7 +19,7 @@ description: Things for managers to remember during the early days of onboarding
 - [ ] Organize lunch outing (probably to Tataki!)
 - [ ] Give an overview of what the onboarding will look like. This is a good time to walk through the onboarding template.
 - [ ] Introduce new hire to their mentor
-- [ ] When they are set up with Slack add them to the `@developers` [user group](https://artsy.slack.com/admin/user_groups), which should automatically invite them to developer related channels, and invite them to channels relavent to the individual
+- [ ] When they are set up with Slack add them to the `@developers` [user group](https://artsy.slack.com/admin/user_groups) 🔒, which should automatically invite them to developer related channels, and invite them to channels relavent to the individual
 
 ### Week 1
 

--- a/onboarding/sessions/tour-of-collector-ux.md
+++ b/onboarding/sessions/tour-of-collector-ux.md
@@ -17,7 +17,7 @@ There are also links to relevant code and admin interfaces where applicable.
 - We only copy gravity data, meaning there can be some issues when referencing other services in staging (i.e. auctions)
 - Elasticsearch indices are often out-of-date as we do not re-index in staging each week after the copy.
 - Reference:
-  - [db:copy:production:to_staging](https://github.com/artsy/gravity/blob/master/lib/tasks/db_copy.rake#L33-L53) rake task
+  - [db:copy:production:to_staging](https://github.com/artsy/gravity/blob/master/lib/tasks/db_copy.rake#L33-L53) 🔒 rake task
 
 #### Set-up needed before this session
 1. Find a work by a test partner that can be inquired on
@@ -33,10 +33,10 @@ _Tips_:
 1. Sign up for an account/log in (have them sign up with an artsymail account, like sarah+testing@artsymail.com)
   - Sign up modals reflect recent work to consolidate auth modals/behavior
   - Reference:
-    - [User model](https://github.com/artsy/gravity/blob/master/app/models/domain/user.rb)
+    - [User model](https://github.com/artsy/gravity/blob/master/app/models/domain/user.rb) 🔒
     - [Artsy passport (for auth)](https://github.com/artsy/artsy-passport)
     - [Documentation for modals](https://github.com/artsy/reaction/blob/master/docs/authentication.md)
-    - [Administered in Torque](https://admin-staging.artsy.net/users)
+    - [Administered in Torque](https://admin-staging.artsy.net/users) 🔒
 
 2. Go through the onboarding questionnaire
   - This gives us a sense of your purpose for being on Artsy (helpful for marketing) and asks for data that will seed our recommendation algorithms
@@ -51,8 +51,8 @@ _Tips_:
   - **Artworks** (aka "collect page")
     - Elasticsearch-based API returns results
     - Reference:
-      - [Artwork model](https://github.com/artsy/gravity/blob/master/app/models/domain/artwork.rb)
-      - [filter/artworks API](https://github.com/artsy/gravity/blob/master/app/api/v1/filter_endpoint.rb)
+      - [Artwork model](https://github.com/artsy/gravity/blob/master/app/models/domain/artwork.rb) 🔒
+      - [filter/artworks API](https://github.com/artsy/gravity/blob/master/app/api/v1/filter_endpoint.rb) 🔒
       - [Collect app code](https://github.com/artsy/force/tree/master/src/desktop/apps/collect2)
   - **Auctions**
     - Includes all auctions of different types (sorted by "timeliness")
@@ -60,21 +60,21 @@ _Tips_:
       - Online + Live ("LAI" == "Live Auction Integration", sometimes just called "Live Auctions")
       - Online + Event ("Benefit auction live event")
     - Reference:
-      - [Auction (Sale) model](https://github.com/artsy/gravity/blob/master/app/models/domain/sale.rb)
+      - [Auction (Sale) model](https://github.com/artsy/gravity/blob/master/app/models/domain/sale.rb) 🔒
       - [Auctions app code](https://github.com/artsy/force/tree/master/src/desktop/apps/auctions)
-      - [Administered in Ohm](http://auctions-staging.artsy.net/)
+      - [Administered in Ohm](http://auctions-staging.artsy.net/) 🔒
   - **Galleries**
     - Organized by "Partner category"
     - Reference:
-      - [Partner model](https://github.com/artsy/gravity/blob/master/app/models/domain/partner.rb)
+      - [Partner model](https://github.com/artsy/gravity/blob/master/app/models/domain/partner.rb) 🔒
       - [Galleries app code](https://github.com/artsy/force/tree/master/src/desktop/apps/galleries_institutions)
       - [Administered in Vibrations](https://admin-partners-staging.artsy.net/)
   - **Fairs**
     - Fair artworks are published a couple of weeks before the fair begins ("Fair preview")
     - Reference:
-      - [Fair model](https://github.com/artsy/gravity/blob/master/app/models/domain/fair.rb)
+      - [Fair model](https://github.com/artsy/gravity/blob/master/app/models/domain/fair.rb) 🔒
       - [Fairs app code](https://github.com/artsy/force/tree/master/src/desktop/apps/fairs)
-      - [Administered in Waves](https://admin-fairs-staging.artsy.net/)
+      - [Administered in Waves](https://admin-fairs-staging.artsy.net/) 🔒
   - **Magazine**
     - Curated by our Editorial team
     - Reference:
@@ -90,12 +90,12 @@ _Tips_:
   - **Artist page**
     - Recently made this page responsive. Is a top entry-point for "shopping" for an artist's work
     - Reference:
-      - [Artist model](https://github.com/artsy/gravity/blob/master/app/models/domain/artist.rb)
+      - [Artist model](https://github.com/artsy/gravity/blob/master/app/models/domain/artist.rb) 🔒
       - [Artist app code (Force)](https://github.com/artsy/force/tree/master/src/desktop/apps/artist)
       - [Artist app code (Reaction)](https://github.com/artsy/reaction/tree/master/src/Apps/Artist)
   - **Auction page**
     - Reference:
-      - [filter/sale_artworks API](https://github.com/artsy/gravity/blob/master/app/api/v1/filter_endpoint.rb)
+      - [filter/sale_artworks API](https://github.com/artsy/gravity/blob/master/app/api/v1/filter_endpoint.rb) 🔒
       - [Auction app code](https://github.com/artsy/force/tree/master/src/desktop/apps/auction)
   - **Gallery profile page**
     - URL is not namespaced by "/gallery" for marketing reasons, but takes the form https://staging.artsy.net/pace-slash-macgill-gallery
@@ -114,11 +114,11 @@ _Tips_:
 5. Follow an artist/gallery/category from the UI
   - Notice that these now show up in your user settings (and will continue to power recs, similarity, etc.)
   - Reference:
-    - [FollowArtist model](https://github.com/artsy/gravity/blob/master/app/models/domain/follow_artist.rb)
+    - [FollowArtist model](https://github.com/artsy/gravity/blob/master/app/models/domain/follow_artist.rb) 🔒
 
 6. Save an artwork for later
   - Reference:
-    - [CollectedArtwork model](https://github.com/artsy/gravity/blob/master/app/models/domain/collected_artwork.rb)
+    - [CollectedArtwork model](https://github.com/artsy/gravity/blob/master/app/models/domain/collected_artwork.rb) 🔒
 
 ### Ways that you can buy art as an Artsy user...
 1. Inquire on an artwork that is owned by a known test account (i.e. Invoicing Demo Partner)
@@ -127,10 +127,10 @@ _Tips_:
   - Collectors can respond via Messaging (in the iOS app) or email
   - Inquiries are a key metric for our teams as it can indicate an intent to buy (and eventually lead to a purchase)
   - Reference:
-    - [Inquiry model](https://github.com/artsy/gravity/blob/master/app/models/domain/inquiry_request.rb)
-    - [Conversation model in Impulse](https://github.com/artsy/impulse/blob/master/app/models/conversation.rb)
-    - [Message model in Radiation](https://github.com/artsy/radiation/blob/master/app/models/message.rb)
-    - [Conversations app in CMS](https://github.com/artsy/volt/tree/master/app/views/conversations)
+    - [Inquiry model](https://github.com/artsy/gravity/blob/master/app/models/domain/inquiry_request.rb) 🔒
+    - [Conversation model in Impulse](https://github.com/artsy/impulse/blob/master/app/models/conversation.rb) 🔒
+    - [Message model in Radiation](https://github.com/artsy/radiation/blob/master/app/models/message.rb) 🔒
+    - [Conversations app in CMS](https://github.com/artsy/volt/tree/master/app/views/conversations) 🔒
 
 2. Respond to an inquiry with an invoice, and pay for it
   - An inquiry may have an invoice attached from a gallery
@@ -143,20 +143,20 @@ _Tips_:
 3. Register for an auction
   - Some auctions require that you are _approved_ by an admin before you are allowed to bid
   - Reference:
-    - [Bidder model](https://github.com/artsy/gravity/blob/master/app/models/domain/bidder.rb)
+    - [Bidder model](https://github.com/artsy/gravity/blob/master/app/models/domain/bidder.rb) 🔒
 
 4. Bid in an online-only auction
   - This creates a max bid (meaning, you agree to pay _up to_ that amount for the work).
   - When the auction ends, the highest bidder wins
   - Reference:
-    - [BidderPosition model](https://github.com/artsy/gravity/blob/master/app/models/domain/bidder_position.rb)
+    - [BidderPosition model](https://github.com/artsy/gravity/blob/master/app/models/domain/bidder_position.rb) 🔒
 
 5. Bid in a live auction (and pull up operator to show the live auction process)
   - The operator keeps track of progress in the room
   - You can jump in at any time to bid that _exact_ amount
   - Reference:
-    - [Live bidding in Causality (model/engine)](https://github.com/artsy/causality)
-    - [Live bidding from Prediction (operator/bidder UI)](https://github.com/artsy/prediction)
+    - [Live bidding in Causality (model/engine)](https://github.com/artsy/causality) 🔒
+    - [Live bidding from Prediction (operator/bidder UI)](https://github.com/artsy/prediction) 🔒
 
 6. Buy a work through the e-commerce checkout flow
   - When you buy through e-commerce, the artwork is immediately marked as Sold. Partners approve your order at which point you are charged for it.

--- a/playbooks/data-migrations.md
+++ b/playbooks/data-migrations.md
@@ -18,7 +18,7 @@ We want to move quickly, so it's in our interest to get good at aggressive chang
 - Just as with code changes, develop locally and apply the migration to staging before production.
 - Before applying a migration to production, back up the impacted data. In gravity, back-ups to the `artsy-data` S3
   bucket are as simple as `rake db:production:backup:to_s3[collection_names]`
-  ([docs](https://github.com/artsy/gravity/blob/master/doc/ProductionBackups.md#backing-up-a-single-collection)).
+  ([docs](https://github.com/artsy/gravity/blob/master/doc/ProductionBackups.md#backing-up-a-single-collection) 🔒).
 - If systems will be in a temporarily broken state prior to the migration being applied, consider how to break the
   change into more graceful deploy steps (e.g., supporting old and new fields concurrently as an intermediate
   step).

--- a/playbooks/engineer-workflow.md
+++ b/playbooks/engineer-workflow.md
@@ -24,7 +24,7 @@ description: How we work together
 
 ## Project Management
 
-Teams at Artsy work with product management [via Jira](https://artsyproduct.atlassian.net/). Teams tend to work in
+Teams at Artsy work with product management [via Jira](https://artsyproduct.atlassian.net/) 🔒. Teams tend to work in
 2 week sprints, with a planning meeting at the start and a review/retrospective at the end.
 
 ## Workflow
@@ -112,8 +112,8 @@ an RFC with an explanation of why, you can check out
 
 Further reading:
 
-- See some epic examples of great PRs: [artsy/gravity#9787](https://github.com/artsy/gravity/pull/9787),
-  [artsy/gravity#9557](https://github.com/artsy/gravity/pull/9557)
+- See some epic examples of great PRs: [artsy/gravity#9787](https://github.com/artsy/gravity/pull/9787) 🔒,
+  [artsy/gravity#9557](https://github.com/artsy/gravity/pull/9557) 🔒
 - [On empathy and pull requests](https://slack.engineering/on-empathy-pull-requests-979e4257d158)
 - [Rules of communicating at GitHub](http://ben.balter.com/2014/11/06/rules-of-communicating-at-github/)
 
@@ -144,7 +144,7 @@ our efforts, so are worth significant investment despite being disconnected from
 
 Finally, Artsy aims for a culture of continuous improvement to both code _and_ process. We try to share wins, teach
 best practices and offer constructive feedback. Tools like lunch-and-learns,
-[postmortems](https://github.com/artsy/post_mortems), [kaizen](https://en.wikipedia.org/wiki/Kaizen) or
+[postmortems](https://github.com/artsy/post_mortems) 🔒, [kaizen](https://en.wikipedia.org/wiki/Kaizen) or
 [retrospectives](https://en.wikipedia.org/wiki/Retrospective) help us reflect on our own practices and make change.
 
 ## Coordinating between teams
@@ -168,10 +168,10 @@ compromises in pursuit of a healthful state.
 ## Documentation
 
 Teams and projects change to adapt to business needs. Code repositories come and go as well, but usually more
-slowly. The [project map](https://github.com/artsy/potential/wiki/Project-List) aims to list all the repositories
+slowly. The [project map](https://github.com/artsy/potential/wiki/Project-List) 🔒 aims to list all the repositories
 that Artsy maintains, organized by the responsible team.
 
-Product team [slack channels](https://artsy.slack.com) are usually the first stop for help in a given team's area
+Product team [slack channels](https://artsy.slack.com) 🔒 are usually the first stop for help in a given team's area
 of responsibility.
 
 Project README files should provide enough context to understand and contribute to a project including:
@@ -187,4 +187,4 @@ Project README files should provide enough context to understand and contribute 
 - Instructions for setting up, testing, and contributing to the project
 - License (probably [MIT](https://opensource.org/licenses/MIT)) and copyright, if open source
 
-See a [recent example](https://github.com/artsy/impulse#impulse-) as a template.
+See a [recent example](https://github.com/artsy/impulse#impulse-) 🔒 as a template.

--- a/playbooks/extracting-services.md
+++ b/playbooks/extracting-services.md
@@ -5,7 +5,7 @@ description: When and why to consider extracting or decoupling systems
 
 ## Monoliths vs. microservices
 
-The [Gravity](https://github.com/artsy/gravity/) project once encapsulated Artsy's entire product, but as the team
+The [Gravity](https://github.com/artsy/gravity/) 🔒 project once encapsulated Artsy's entire product, but as the team
 grew in size and the product in complexity, it became difficult to reason about all of the system's interconnected
 parts. Tests became slow, and minor changes became bogged down in seemingly unrelated obstacles.
 

--- a/playbooks/support/README.md
+++ b/playbooks/support/README.md
@@ -22,7 +22,7 @@ The schedule is configured on the
 Trading shifts (because of vacations, obligations, etc.) is encouraged as long as the calendar is kept up-to-date. Please address any scheduling issues as early as possible.
 
 During work hours, on-call engineers are responsible for responding to issues in
-[the #incidents slack channel](https://artsy.slack.com/messages/C9RK0BLEP/) in a timely fashion. Outside of work
+[the #incidents slack channel](https://artsy.slack.com/messages/C9RK0BLEP/) 🔒 in a timely fashion. Outside of work
 hours, engineers are _only_ responsible for downtime issues.
 
 The two engineers who are on-call are free to split the responsibility for monitoring outside of work hours, but we
@@ -40,7 +40,7 @@ ongoing sprint and team activities.
 
 - On-call is a 24/7 responsibility (for critical issues). The non-work hours can be split across the on-call
   engineers and over timezones where appropriate.
-- Monitor the [#incidents slack channel](https://artsy.slack.com/messages/C9RK0BLEP/) for critical issues.
+- Monitor the [#incidents slack channel](https://artsy.slack.com/messages/C9RK0BLEP/) 🔒 for critical issues.
 - Look out for trends and create bugs (in the
   [universal bug backlog](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=34)) where necessary
   that can be triaged into individual teams' sprints by a PM.
@@ -48,13 +48,13 @@ ongoing sprint and team activities.
 
 #### 2. Investigate and address critical issues
 
-- Acknowledge the issue in slack (escalate to the [#incidents](https://artsy.slack.com/messages/C9RK0BLEP/) channel
+- Acknowledge the issue in slack (escalate to the [#incidents](https://artsy.slack.com/messages/C9RK0BLEP/) 🔒 channel
   if not already there)
 - **Use slack threads** to keep the channel and its notifications focused, and allow others to monitor for new
   incidents at a glance.
 - Investigate the issue individually and as a pair.
 - Judge the severity (based on intuition or a helpful PM/business owner)
-- Fix if possible using [accumulated playbooks (wiki)](https://github.com/artsy/potential/wiki).
+- Fix if possible using [accumulated playbooks (wiki)](https://github.com/artsy/potential/wiki) 🔒.
 - If unable to fix using shared resources, contact the relevant [point-person](#point-people) for help and pair
   with them on a fix. Be sure to contribute lessons back to shared documentation. **You are not expected to know the ins and outs of every system, so don't hesitate to involve the wider team.**
 - Point-people should only be contacted during off-hours for outages that the on-call engineers are unable to
@@ -94,7 +94,7 @@ Tips for using the incidents Trello:
 
 ## Handing-off to a new shift
 
-After [engineering-wide stand-up](https://github.com/artsy/potential#engineering-wide-standup) is a good time for
+After [engineering-wide stand-up](https://github.com/artsy/potential#engineering-wide-standup) 🔒 is a good time for
 the coming and going on-call engineers to sync up and hand off any ongoing responsibilities. Customarily we:
 
 - Update the "Resolved" column in [the Incidents trello](https://trello.com/b/sZQ9qpVo/incidents) with the past
@@ -103,31 +103,31 @@ the coming and going on-call engineers to sync up and hand off any ongoing respo
   final action items for the departing team to fully resolve them (like creating Jira tickets, releasing PRs,
   etc.).
 - Finally, the departing team should take this opportunity to update
-  [the accumulated playbooks](https://github.com/artsy/potential/wiki) with any last lessons.
+  [the accumulated playbooks](https://github.com/artsy/potential/wiki) 🔒 with any last lessons.
 
 ## Point-people
 
-You can find the point people in the [Potential Wiki](https://github.com/artsy/potential/wiki).
+You can find the point people in the [Potential Wiki](https://github.com/artsy/potential/wiki) 🔒.
 
 ## Helpful Resources and Playbooks
 
 ### Slack channels
 
-- [#incidents](https://artsy.slack.com/messages/C9RK0BLEP/) requires close monitoring (30 min. response is
+- [#incidents](https://artsy.slack.com/messages/C9RK0BLEP/) 🔒 requires close monitoring (30 min. response is
   expected). This is where urgent issues are raised, either manually or via automated alerts.
-- [#alerts](https://artsy.slack.com/messages/C0HP61PUJ/) should be monitored during business and waking hours.
+- [#alerts](https://artsy.slack.com/messages/C0HP61PUJ/) 🔒 should be monitored during business and waking hours.
   These automated system alerts _may_ be the first sign of a problem but don't _necessarily_ warrant treatment as
   immediate incidents. E.g., load-balancers may route around failing EC2 instances or auto-scaling may bring up
   capacity in response to load.
 - Artsy team members can get help from peers in these additional channels:
-  - [#gallery-help](https://artsy.slack.com/messages/C7LEJU1QU/): for GR team to get help from their peers on
+  - [#gallery-help](https://artsy.slack.com/messages/C7LEJU1QU/) 🔒: for GR team to get help from their peers on
     common issues
-  - [#auctions-ops](https://artsy.slack.com/messages/C0RTGJHDG/): where the auctions ops team may discuss issues
+  - [#auctions-ops](https://artsy.slack.com/messages/C0RTGJHDG/) 🔒: where the auctions ops team may discuss issues
     they are having/help each other
 
 ### Engineering team playbooks
 
-- [The wiki](https://github.com/artsy/potential/wiki) contains playbooks of support procedures for various teams
+- [The wiki](https://github.com/artsy/potential/wiki) 🔒 contains playbooks of support procedures for various teams
   and systems.
 - [Setting up Slack Notifications](https://github.com/artsy/README/blob/master/playbooks/support/slack-notifications.md)
 
@@ -138,9 +138,9 @@ You can find the point people in the [Potential Wiki](https://github.com/artsy/p
 
 ### Artsy domain information
 
-- [Engineering projects map](https://github.com/artsy/potential/wiki/Project-List)
-- [Monitoring](https://github.com/artsy/potential/blob/master/platform/Monitoring.md)
-- [Domain Models](https://github.com/artsy/potential/blob/master/platform/DomainModels.md)
+- [Engineering projects map](https://github.com/artsy/potential/wiki/Project-List) 🔒
+- [Monitoring](https://github.com/artsy/potential/blob/master/platform/Monitoring.md) 🔒
+- [Domain Models](https://github.com/artsy/potential/blob/master/platform/DomainModels.md) 🔒
 - [Status Page](status.artsy.net)
 
 ## Special cases

--- a/playbooks/technology-choices.md
+++ b/playbooks/technology-choices.md
@@ -82,8 +82,8 @@ These are some of the technologies we prefer for common challenges, as well as e
 - **Direct database exports** for extracting data from source systems into Redshift. In general we prefer loading
   raw source data into the warehouse and performing aggregation or calculations there (over synthesizing in source
   apps' code and exporting just the results). See Fulcrum's demonstration of extracting from
-  [Mongodb sources](https://github.com/artsy/fulcrum/blob/master/lib/fulcrum/extract/gravity_extracts.rb) such as
-  Gravity's or [Postgres sources](https://github.com/artsy/fulcrum/blob/master/tasks/extract.rake).
+  [Mongodb sources](https://github.com/artsy/fulcrum/blob/master/lib/fulcrum/extract/gravity_extracts.rb) 🔒 such as
+  Gravity's or [Postgres sources](https://github.com/artsy/fulcrum/blob/master/tasks/extract.rake) 🔒.
 - **Artwork objects** over artwork pages. While much of our early infrastructure focused on serving content in the
   form artsy.net required, we expect our future product needs to demand more accurate representation of art world
   realities. That includes greater pricing variants, traceable provenance, an understanding of condition, physical

--- a/practices/historical/mobile_2015.md
+++ b/practices/historical/mobile_2015.md
@@ -15,8 +15,8 @@ We collectively created an article for the magazine
 ### Onboarding
 
 Most of the general Artsy Developer information for onboarding is covered in
-[artsy/potential](https://github.com/artsy/potential#onboarding) (note to open source community: this is a private
-repo). Further below we have a section on code-signing.
+[artsy/potential](https://github.com/artsy/potential#onboarding) 🔒. Further
+below we have a section on code-signing.
 
 ### My first week
 
@@ -41,7 +41,7 @@ Ideally in your first week you should:
 
   - What have you been up to, what are you planning to do?
 
-- Bi-weekly FeelsBot stand-up (Mon/Thr) posted in [#mobile-banter](https://artsy.slack.com/messages/mobile-banter/)
+- Bi-weekly FeelsBot stand-up (Mon/Thr) posted in [#mobile-banter](https://artsy.slack.com/messages/mobile-banter/) 🔒
 
   - Done anything fun? How are you doing today? Feeling ok?
 
@@ -56,15 +56,15 @@ Ideally in your first week you should:
 - The Mobile team specific
   [calendar](https://www.google.com/calendar/embed?src=artsymail.com_bke4sctkn8o072rjgtcsrrun3s%40group.calendar.google.com&ctz=America/New_York)
   is used for Out Of Office / Events.
-- Chat in [#mobile-banter](https://artsy.slack.com/messages/mobile-banter/)
+- Chat in [#mobile-banter](https://artsy.slack.com/messages/mobile-banter/) 🔒
 - Each app has its own focused channel in Slack - Eigen:
-  [#gmv-ios-dev](https://artsy.slack.com/messages/gmv-ios-dev/), Energy:
-  [#energy](https://artsy.slack.com/messages/energy) and Eidolon:
-  [#auctions-dev](https://artsy.slack.com/messages/auctions-dev/).
+  [#gmv-ios-dev](https://artsy.slack.com/messages/gmv-ios-dev/) 🔒, Energy:
+  [#energy](https://artsy.slack.com/messages/energy) 🔒 and Eidolon:
+  [#auctions-dev](https://artsy.slack.com/messages/auctions-dev/) 🔒.
 - Each app has a user facing slack, which is for bug reports / product discussion:
-  [#gmv-ios](https://artsy.slack.com/messages/gmv-ios/), [#folio](https://artsy.slack.com/messages/folio) and
-  [#auctions](https://artsy.slack.com/messages/auctions/).
-- GitHub notifications, etc. in [#mobile-notifications](https://artsy.slack.com/messages/mobile-notifications/).
+  [#gmv-ios](https://artsy.slack.com/messages/gmv-ios/) 🔒, [#folio](https://artsy.slack.com/messages/folio) 🔒 and
+  [#auctions](https://artsy.slack.com/messages/auctions/) 🔒.
+- GitHub notifications, etc. in [#mobile-notifications](https://artsy.slack.com/messages/mobile-notifications/) 🔒.
 
 ### Getting started
 

--- a/practices/historical/web_2015.md
+++ b/practices/historical/web_2015.md
@@ -17,8 +17,8 @@
   - What are you working on or need help with?
   - Explain any web-wide technical concerns for the week.
   - Props
-- General Chat in [#web](https://artsy.slack.com/messages/web/)
-- Artsy Writer support in [#publishing-support](https://artsy.slack.com/messages/publishing-support/)
+- General Chat in [#web](https://artsy.slack.com/messages/web/) 🔒
+- Artsy Writer support in [#publishing-support](https://artsy.slack.com/messages/publishing-support/) 🔒
 
 ### Our Apps
 
@@ -33,7 +33,7 @@
 - [2014.artsy.net](https://github.com/artsy/2014.artsy.net) 2014 Year in Review.
 - [artsy-2013](https://github.com/artsy/artsy-2013) 2013 Year in Review.
 
-- See the [engineering projects map](https://trello.com/b/VLlTIM7l/artsy-engineering-projects-map) for a
+- See the [engineering projects map](https://trello.com/b/VLlTIM7l/artsy-engineering-projects-map) 🔒 for a
   comprehensive list of Mobile Practice libraries.
 
 ### Our Key Technologies

--- a/practices/historical/web_recommendations_2015.md
+++ b/practices/historical/web_recommendations_2015.md
@@ -41,4 +41,4 @@ Simply put our API is a Ruby powered web server the serves up our data in JSON f
 - [Project website](http://ezeljs.com/)
 - [Blog post introducing it](http://artsy.github.io/blog/2013/11/30/rendering-on-the-server-and-client-in-node-dot-js/)
 
-Good luck, and please ask any questions in the [#web Slack channel](https://artsy.slack.com/messages/web/).
+Good luck, and please ask any questions in the [#web Slack channel](https://artsy.slack.com/messages/web/) 🔒.

--- a/practices/platform.md
+++ b/practices/platform.md
@@ -13,8 +13,8 @@ description: What do folks with a platform focus do?
 
 ### Process
 
-- Automated notifications appear in [#platform-machines](https://artsy.slack.com/messages/platform-machines/)
-- Significant alerts go to [#platform-alerts](https://artsy.slack.com/messages/platform-alerts/)
+- Automated notifications appear in [#platform-machines](https://artsy.slack.com/messages/platform-machines/) 🔒
+- Significant alerts go to [#platform-alerts](https://artsy.slack.com/messages/platform-alerts/) 🔒
 - Fridays are **Future Fridays**, where we take a break from in progress work to focus on longer-term improvements.
   (See [blog post](http://artsy.github.io/blog/2015/12/22/future-fridays/).) _[Experimental]_
 
@@ -28,19 +28,19 @@ description: What do folks with a platform focus do?
 ### Further Platform documentation
 
 A lot of platform practice documentation is inside
-[artsy/potential](https://github.com/artsy/potential/blob/master/platform/)
+[artsy/potential](https://github.com/artsy/potential/blob/master/platform/) 🔒
 
 Artsy's favorite resources (including those of the platform team) are in
 [Tech Learning](/resources/tech_learning.md#platform-practice)
 
-- [AWS](https://github.com/artsy/potential/blob/master/platform/AWS.md)
+- [AWS](https://github.com/artsy/potential/blob/master/platform/AWS.md) 🔒
   ([AWS login](https://artsy.signin.aws.amazon.com/console))
-- [Configuration Management](https://github.com/artsy/potential/blob/master/platform/ConfigurationManagement.md)
-- [Domain Models](https://github.com/artsy/potential/blob/master/platform/DomainModels.md)
-- [Messaging](https://github.com/artsy/potential/blob/master/platform/Messaging.md)
-- [Monitoring](https://github.com/artsy/potential/blob/master/platform/Monitoring.md)
-- [Restoring Data](https://github.com/artsy/potential/blob/master/platform/RestoringData.md)
-- [Working With Gravity](https://github.com/artsy/potential/blob/master/platform/WorkingWithGravity.md)
+- [Configuration Management](https://github.com/artsy/potential/blob/master/platform/ConfigurationManagement.md) 🔒
+- [Domain Models](https://github.com/artsy/potential/blob/master/platform/DomainModels.md) 🔒
+- [Messaging](https://github.com/artsy/potential/blob/master/platform/Messaging.md) 🔒
+- [Monitoring](https://github.com/artsy/potential/blob/master/platform/Monitoring.md) 🔒
+- [Restoring Data](https://github.com/artsy/potential/blob/master/platform/RestoringData.md) 🔒
+- [Working With Gravity](https://github.com/artsy/potential/blob/master/platform/WorkingWithGravity.md) 🔒
 
 ### Our Technologies
 
@@ -51,7 +51,7 @@ through a tutorial, such as [Michael Hartl's Rails Tutorial](https://www.railstu
 
 ### API
 
-Our API is implemented in the [Gravity](https://github.com/artsy/gravity) project and uses
+Our API is implemented in the [Gravity](https://github.com/artsy/gravity) 🔒 project and uses
 [Grape](https://github.com/intridea/grape).
 
 ### Kubernetes
@@ -64,23 +64,23 @@ Some projects leverage [Docker](https://www.docker.com/) and our [Kubernetes](ht
 [Gravity](https://github.com/artsy/gravity) was Artsy’s original monolith and now hosts the main API. Follow the
 [Gravity docs](https://github.com/artsy/gravity/blob/master/doc/GettingStarted.md) to get set up, or this
 introduction:
-[Working with Gravity](https://github.com/artsy/potential/blob/master/platform/WorkingWithGravity.md).
+[Working with Gravity](https://github.com/artsy/potential/blob/master/platform/WorkingWithGravity.md) 🔒.
 
 ### Major systems:
 
-- Gravity/api.artsy.net: https://github.com/artsy/gravity/
+- Gravity/api.artsy.net: https://github.com/artsy/gravity/ 🔒
 - Force/www.artsy.net: https://github.com/artsy/force/
 - Metaphysics (graphql layer)/metaphysics-production.artsy.net: https://github.com/artsy/metaphysics/
 - iPhone app: https://github.com/artsy/eigen/
-- CMS/cms.artsy.net: https://github.com/artsy/volt/
-- Causality (bidding engine): https://github.com/artsy/causality/
-- Fulcrum (data pipeline): https://github.com/artsy/fulcrum/
-- Impulse (sales conversations): https://github.com/artsy/impulse/
-- Pulse (messaging): https://github.com/artsy/pulse/
-- Infrastructure (terraform and other configuration management): https://github.com/artsy/infrastructure/
-- Substance (scripts, etc. for managing our Kubernetes cluster): https://github.com/artsy/substance/
+- CMS/cms.artsy.net: https://github.com/artsy/volt/ 🔒
+- Causality (bidding engine): https://github.com/artsy/causality/ 🔒
+- Fulcrum (data pipeline): https://github.com/artsy/fulcrum/ 🔒
+- Impulse (sales conversations): https://github.com/artsy/impulse/ 🔒
+- Pulse (messaging): https://github.com/artsy/pulse/ 🔒
+- Infrastructure (terraform and other configuration management): https://github.com/artsy/infrastructure/ 🔒
+- Substance (scripts, etc. for managing our Kubernetes cluster): https://github.com/artsy/substance/ 🔒
 
 In general, see project READMEs for project details including links, CI, deployment instructions, and point-people.
 
-The full [project list](https://github.com/artsy/potential/wiki/Project-list) has a more exhaustive list of Artsy's
-systems.
+The full [project list](https://github.com/artsy/potential/wiki/Project-list) 🔒
+has a more exhaustive list of Artsy's systems.


### PR DESCRIPTION
I like the idea introduced in https://github.com/artsy/README/pull/78 to add a padlock icon next to external links leading to content unavailable to readers outside of the Artsy organization.

I've added that helpful icon to other links in the repository. Probably missed a bunch, but I think this covers most.