### PR TITLE
Updates Lunch&Learn time to 12:30

### DIFF
--- a/events/lunch-and-learn.md
+++ b/events/lunch-and-learn.md
@@ -12,7 +12,7 @@ This worked for a while, but was sporadic and mostly the same speakers. Once we 
 [a new stand-up format](http://artsy.github.io/blog/2015/03/23/artsy-technology-stack-2015/) it felt like time to
 re-vamp our brown bags too.
 
-Our format is pretty simple, every Thursday we have an hour slot at 12 (NYC time) on the calendar for someone to
+Our format is pretty simple, every Thursday we have an hour slot at 12:30 (NYC time) on the calendar for someone to
 give a talk or presentation. I think [Alan](http://twitter.com/alanjay1/) described it well on
 [Professional Development at Artsy](http://artsy.github.io/blog/2016/09/22/professional-development-at-artsy-engineering/):
 
@@ -78,11 +78,11 @@ architecture.
 
 ## Schedule
 
-- Arrive at Artsy for 11:45am ( We're [401 Broadway, 26th Floor, 10013][401] - Canal St is the closest station)
-- Our receptionist will get in touch with whoever you've been in contact with, probably [Orta] or [Ash]
+- Arrive at Artsy for 12:15am (we're [401 Broadway, 26th Floor, 10013][401] - Canal St is the closest station)
+- Our receptionist on 26 will get in touch with whoever you've been in contact with, probably [Orta][] or [Ash][]
 - They will get you set up on our 27th floor Classroom
 - We will set up [a stream](#recording) for global developers and slides
-- There are inevitable technical difficulties (~10 minutes)
+- We have until 12:30 to get any technical difficulties sorted out ([the docs are here][trouble])
 - You give a presentation (~30 minutes)
 - We ask a bunch of questions (~15 minutes)
 - Whoever helped get you set up takes you out for lunch on us
@@ -94,17 +94,19 @@ like.
 ## Recording
 
 We ask that we can share a livestream of your talk, because we have a lot of
-[global developers](https://www.artsy.net/article/eloy-duran-going-global-5-tips-to-make-remote-work). This is just
-loading a Zoom.us link on your computer and sharing your screen.
+[global colleagues](https://www.artsy.net/article/eloy-duran-going-global-5-tips-to-make-remote-work). This
+involves loading a [Zoom.us][] link on your computer and sharing your screen.
 
-We also ask that we get a screen recording of your talk, just internally, for colleagues who couldn't attend or
-want to review your awesome talk later. This is also done through Zoom.us. We'd like to get a copy of your slides,
-too. Of course, we're happy to send you a copy of the recording.
+We also ask that we get a recording of the talk (kept internal within Artsy), for colleagues who couldn't attend or
+want to review your awesome talk later. This is done through Zoom.us for you, not setup required. We'd like to get
+a copy of your slides, too. Of course, we're happy to send you a copy of the recording.
 
-If you don't want to be recorded, we understand that you might talk and show things that are not for public
-consumption. We can skip the screen recording. We will not share anything externally without your express opinion.
+**If you don't want to be recorded, no problem**. We understand that you might talk and show things that are not
+for public consumption. We will not share anything externally without your express permission.
 
 [orta]: https://github.com/orta
 [ash]: https://github.com/ashfurrow
 [401]:
   https://www.google.com/maps/place/401+Broadway/@40.718958,-74.0049492,17z/data=!3m1!4b1!4m5!3m4!1s0x89c2598a7196824f:0xddf53435afbdd5b9!8m2!3d40.718954!4d-74.0027552
+[trouble]: https://github.com/artsy/README/blob/master/playbooks/running-lunch-and-learn.md#troubleshooting
+[zoom.us]: https://zoom.us

--- a/events/lunch-and-learn.md
+++ b/events/lunch-and-learn.md
@@ -98,8 +98,8 @@ We ask that we can share a livestream of your talk, because we have a lot of
 involves loading a [Zoom.us][] link on your computer and sharing your screen.
 
 We also ask that we get a recording of the talk (kept internal within Artsy), for colleagues who couldn't attend or
-want to review your awesome talk later. This is done through Zoom.us for you, not setup required. We'd like to get
-a copy of your slides, too. Of course, we're happy to send you a copy of the recording.
+want to review your awesome talk later. This is done through Zoom.us automatically, no additional setup is
+required. We'd like to get a copy of your slides, too. Of course, we're happy to send you a copy of the recording.
 
 **If you don't want to be recorded, no problem**. We understand that you might talk and show things that are not
 for public consumption. We will not share anything externally without your express permission.

--- a/events/open-standup.md
+++ b/events/open-standup.md
@@ -20,21 +20,25 @@ The person handling the talking parts does this stuff ten minutes before standup
 - Remind last week's on-call staff in #dev to prepare their updates about last week's rotation. Something like:
   > @personA @personB reminder, we're looking for a list of major or notable incidents from last week during
   > standup.
+- Check the [Lunch&Learn shchedule][ll_schedule].
+- Think of who you'd like to give props to.
 
 ### During standup
 
 - **Important**: Make sure the person taking notes doesn't have their laptop next to the Zoom speakerphone.
 - We start off with props, as a nod towards [People are Paramount][pplp]
 - Then we get an update from the CTO
-- Then an update from the Product team (someone should be present to give one)
+- Then an update from the Product managers (someone should be present to give one)
 - Then we get updates on new hires, people starting this week, newly accepted offers and etc.
 - Then an update from last week's on-call support team, including follow-up work items
 - We leave a spot for potential cross-team issues
-- We have a spot to talk about things people are proud of
+- We list any open RFCs (see #dev channel in Slack, they get posted every Monday morning)
+- We have a Milestones spot to talk about things people are proud of
 - We then either announce [the Lunch & Learn][ll], or try find one for the week
+- Anyone is free to give closing announcements, or props!
 
-These notes are then copied into a Notion document, and the link passed into #dev on Slack after standup. Everyone
-else leaves links to things they have commented on during the meeting, if they don't, we chase them up.
+These notes are then copied into a [Notion][] document, and the link passed into #dev on Slack after standup.
+Everyone else leaves links to things they have commented on during the meeting, if they don't, we chase them up.
 
 ## Our Markdown Template
 
@@ -79,13 +83,15 @@ _Lunch & Learn_ (if you don't know, ask in #lunch_and_learn)
 _Closing Announcements_
 
 - Show & Tell is this Friday at 11:00 NYC time in the Studio on 24 (and over Zoom). See the docs for more info:
-  https://github.com/artsy/meta/blob/master/meta/show_and_tell.md
+  https://github.com/artsy/README/blob/master/events/show-and-tell.md
 - The last two support engineers should stick around to chat with us, the new support engineers after this meeting.
 - We'll also be having the front-end office hours right after this meeting, so stick around if you have questions.
 -
 ```
 
-Once you're done, follow the instructions [in Notion](https://www.notion.so/artsy/Standup-Notes-28a5dfe4864645788de1ef936f39687c) on how to add it to our archives.
+Once you're done, follow the instructions [in Notion][notion] on how to add it to our archives.
 
-[pplp]: https://github.com/artsy/meta/blob/master/meta/what_is_artsy.md#people-are-paramount
-[ll]: https://github.com/artsy/meta/blob/master/meta/lunch_and_learn.md
+[pplp]: https://github.com/artsy/README/blob/master/culture/what-is-artsy.md#people-are-paramount
+[ll]: https://github.com/artsy/README/blob/master/events/lunch-and-learn.md
+[ll_schedule]: https://github.com/artsy/README/projects/1
+[notion]: https://www.notion.so/artsy/Standup-Notes-28a5dfe4864645788de1ef936f39687c

--- a/playbooks/running-lunch-and-learn.md
+++ b/playbooks/running-lunch-and-learn.md
@@ -51,11 +51,17 @@ event. Just follow these steps:
 
 ### The Day Of
 
-Be on 26 at 11:40 to receive our guest. Take them upstairs and while they're getting set up, offer some water. Get
-them set up on the Zoom.us meeting and remind them that you'll take them out for lunch afterward.
+We have The Classroom booked from 12:00–12:30 for setup, so go check at noon that everything is working:
 
-At 11:50, send an `@here` reminder in the #dev (also post in #general). Give folks a few minutes past noon to show
-up, but don't hold the show up waiting for them.
+- [ ] TV is turned on.
+- [ ] Zoom iPad is on and plugged in.
+
+Be on 26 at 12:10 to receive our guest (they should have been asked to arrive at 12:15). Take them upstairs and
+while they're getting set up, offer some water. Get them set up on the Zoom.us meeting and remind them that you'll
+take them out for lunch afterward.
+
+At 12:20, send an `@here` reminder in the #dev (also post in #general if applicable). Give folks a few minutes past
+12:30 to show up, but don't hold the show up waiting for them.
 
 Immediately before you present the speaker, hit the record button in Zoom.us and it'll ask you for your email
 address.
@@ -79,13 +85,13 @@ Move the card to the "Done" column. Nice work!
 
 ##### Connecting to the screen
 
-- For Artsy staff, they should be on the staff WIFI and connect via AirPlay to "27 - Classroom"
+- For Artsy staff, they should be on the staff WiFi and connect via AirPlay to "27 - Classroom"
 - For external folk:
-  - They can join the zoom url
-    [https://zoom.us/my/artsyclassroom](https://zoom.us/my/artsyclassroom). You
-    can also email the zoom URL to the speaker from the iPad.
+
+  - They can join the zoom url [https://zoom.us/my/artsyclassroom](https://zoom.us/my/artsyclassroom). You can also
+    email the zoom URL to the speaker from the iPad.
   - You can run their slides on your computer
-  
+
 ##### The zoom isn't available
 
 - Make sure the Mac mini behind the screen is turned on
@@ -96,7 +102,7 @@ Move the card to the "Done" column. Nice work!
 - Check the TV is on
 - Check that it's on the right input source (HDMI)
 - Go behind the TV, and pull out the power and re-connect it
-  
+
 ##### Audio problems
 
 - Check the revolabs microphone is plugged in and has green lights


### PR DESCRIPTION
This PR updates our documentation to reflect the new time of Lunch & Learns from [this RFC](https://github.com/artsy/potential/issues/195). I also freshened up our Monday standup docs to fix some formatting problems and old links.

@erikdstock Once this is merged, make sure to resolve the RFC (the docs are [here](https://github.com/artsy/README/blob/master/playbooks/rfcs.md#resolution)).