### PR TITLE
Try to document where documents should go

### DIFF
--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -23,6 +23,7 @@ practice should be incorporated, submit a PR!
 | [Conferences](/playbooks/conferences.md#readme) | Attending or speaking at a conference |
 | [Data Migrations](/playbooks/data-migrations.md#readme) | Preparing, reviewing and executing data migrations |
 | [Deployments](/playbooks/deployments.md#readme) | How systems are deployed at Artsy |
+| [Documentation](/playbooks/documentation.md#readme) | How and where to document or share content |
 | [Engineer workflow](/playbooks/engineer-workflow.md#readme) | How we work together |
 | [Extracting Services](/playbooks/extracting-services.md#readme) | When and why to consider extracting or decoupling systems |
 | [GraphQL Schema Design](/playbooks/graphql-schema-design.md#readme) | What are our best practices for GraphQL Schema Design? |
@@ -33,7 +34,6 @@ practice should be incorporated, submit a PR!
 | [How to run a retrospective](/playbooks/retrospectives.md#readme) | The why and how for running a retrospective |
 | [How to create an RFC at Artsy](/playbooks/rfcs.md#readme) | The steps needed to request cultural changes |
 | [How to run a Lunch & Learn](/playbooks/running-lunch-and-learn.md#readme) | How to handle the people process for Lunch & Learns |
-| [The Artsy Engineering Support process](/playbooks/support#readme) | A process overview and some tips and tricks. |
 | [Technology choices](/playbooks/technology-choices.md#readme) | Evaluating and adopting new technology at Artsy |
 <!-- end_toc -->
 <!-- prettier-ignore-end -->

--- a/playbooks/documentation.md
+++ b/playbooks/documentation.md
@@ -19,12 +19,11 @@ E.g.:
 - Definitions of domain models
 - API documentation
 
-It _almost_ goes without saying, but other repo-specific interactions such as presenting the rationale for a design
-or offering code-review should leverage the built-in mechanisms of
-[commit messages](/playbooks/engineer-workflow.md#commits),
+Other repo-specific interactions such as presenting the rationale for a design or offering code-review should
+leverage the built-in mechanisms of [commit messages](/playbooks/engineer-workflow.md#commits),
 [pull requests](/playbooks/engineer-workflow.md#pull-requests), and comments.
 
-## Public versus private
+## Public versus private content
 
 When creating a repo, contributing a doc, or discussing in-progress work, consider whether it's appropriate for
 this content to be public or private.
@@ -36,32 +35,34 @@ Content that should always be private:
 - Production data or logs (including indirectly through migration output, etc.)
 - Repositories representing substantial business value, novelty, or criticality (such as the main API, content
   management system, or auction operator tools)
+- Security or compliance topics, including pending security work items or vulnerability-handling procedures
 
 Content that _maybe_ should be private, depending on its sensitivity:
 
-- Security or compliance topics, including pending security work items or vulnerability-handling procedures
 - Incident/support instructions, including data recovery or incident-mitigation procedures
-- Sensitive business rules, definitions, or implementations (tiering, targeting, buyer/bidder qualification, spam
+- Internal business rules, definitions, or implementations (tiering, targeting, buyer/bidder qualification, spam
   heuristics, search ranking algorithms, data partnerships...)
 - Un-announced feature work
-- Industry or user research or analysis that may hold some competitive value
+- User research or industry analysis that may hold competitive value
 - References to private content (according to the criteria above) including documentation of private systems, links
   to private gists that may include private data or logs, etc.
 
-## General engineering content
+## Engineering content _not_ specific to repos
 
-This public [artsy/README](https://github.com/artsy/readme) repo is our default location for shared engineering
+This public [artsy/README](https://github.com/artsy/readme) repo is our default location for general engineering
 content such as:
 
 - onboarding resources
 - team procedures and playbooks
+- other public resources that are not repo-specific
 
-The private [artsy/potential](https://github.com/artsy/potential) repo supplements that with internal resources
-such as:
+The private [artsy/potential](https://github.com/artsy/potential) repo supplements artsy/README with resources such
+as:
 
 - documentation and diagrams of internal architecture
 - security bounty program procedures
 - playbooks for handling common on-call incidents (see [the wiki](https://github.com/artsy/potential/wiki))
+- any other content that should be private according to the criteria above
 
 ## Engineering blog
 

--- a/playbooks/documentation.md
+++ b/playbooks/documentation.md
@@ -1,0 +1,78 @@
+---
+title: Documentation
+description: How and where to document or share content
+---
+
+# Documentation
+
+As engineers we operate in many parallel forums: Github, Jira, Slack, Google docs, e-mail, Notion, and so on. What
+content should go where?
+
+## Documentation or discussion of a specific system
+
+When documentation relates to a particular system, leverage in-repository `README`s or `doc/`s wherever possible.
+This includes when the consumers may not exclusively be engineers.
+
+E.g.:
+
+- How to set-up a local development environment
+- Definitions of domain models
+- API documentation
+
+It _almost_ goes without saying, but other repo-specific interactions such as presenting the rationale for a design
+or offering code-review should leverage the built-in mechanisms of
+[commit messages](/playbooks/engineer-workflow.md#commits),
+[pull requests](/playbooks/engineer-workflow.md#pull-requests), and comments.
+
+## Public versus private
+
+When creating a repo, contributing a doc, or discussing in-progress work, consider whether it's appropriate for
+this content to be public or private.
+
+Content that should always be private:
+
+- Contact or role details for individuals
+- Information about candidates or new hires before they've joined or consented to announce their move
+- Production data or logs (including indirectly through migration output, etc.)
+- Repositories representing substantial business value, novelty, or criticality (such as the main API, content
+  management system, or auction operator tools)
+
+Content that _maybe_ should be private, depending on its sensitivity:
+
+- Security or compliance topics, including pending security work items or vulnerability-handling procedures
+- Incident/support instructions, including data recovery or incident-mitigation procedures
+- Sensitive business rules, definitions, or implementations (tiering, targeting, buyer/bidder qualification, spam
+  heuristics, search ranking algorithms, data partnerships...)
+- Un-announced feature work
+- Industry or user research or analysis that may hold some competitive value
+- References to private content (according to the criteria above) including documentation of private systems, links
+  to private gists that may include private data or logs, etc.
+
+## General engineering content
+
+This public [artsy/README](https://github.com/artsy/readme) repo is our default location for shared engineering
+content such as:
+
+- onboarding resources
+- team procedures and playbooks
+
+The private [artsy/potential](https://github.com/artsy/potential) repo supplements that with internal resources
+such as:
+
+- documentation and diagrams of internal architecture
+- security bounty program procedures
+- playbooks for handling common on-call incidents (see [the wiki](https://github.com/artsy/potential/wiki))
+
+## Engineering blog
+
+Finally, don't forget about [artsy.github.io](https://artsy.github.io), the engineering blog. Blog posts can be
+great resources both externally _and_ internally when you've released a new library, solved a technical challenge,
+refined tooling, or just learned a lesson that might be of interest to other teams like ours.
+
+## Resources
+
+- [engineer-workflow.md](/playbooks/engineer-workflow.md)
+- [issues/2](https://github.com/artsy/README/issues/2) about public vs. private content
+- [artsy/README](https://github.com/artsy/readme)
+- [artsy/potential](https://github.com/artsy/potential)
+- [artsy.github.io](https://artsy.github.io)

--- a/playbooks/engineer-workflow.md
+++ b/playbooks/engineer-workflow.md
@@ -24,8 +24,8 @@ description: How we work together
 
 ## Project Management
 
-Teams at Artsy work with product management [via Jira](https://artsyproduct.atlassian.net/) 🔒. Teams tend to work in
-2 week sprints, with a planning meeting at the start and a review/retrospective at the end.
+Teams at Artsy work with product management [via Jira](https://artsyproduct.atlassian.net/) 🔒. Teams tend to work
+in 2 week sprints, with a planning meeting at the start and a review/retrospective at the end.
 
 ## Workflow
 
@@ -171,11 +171,11 @@ compromises in pursuit of a healthful state.
 ## Documentation
 
 Teams and projects change to adapt to business needs. Code repositories come and go as well, but usually more
-slowly. The [project map](https://github.com/artsy/potential/wiki/Project-List) 🔒 aims to list all the repositories
-that Artsy maintains, organized by the responsible team.
+slowly. The [project map](https://github.com/artsy/potential/wiki/Project-List) 🔒 aims to list all the
+repositories that Artsy maintains, organized by the responsible team.
 
-Product team [slack channels](https://artsy.slack.com) 🔒 are usually the first stop for help in a given team's area
-of responsibility.
+Product team [slack channels](https://artsy.slack.com) 🔒 are usually the first stop for help in a given team's
+area of responsibility.
 
 Project README files should provide enough context to understand and contribute to a project including:
 


### PR DESCRIPTION
It resurfaced today that there's continuing ambiguity about where different types of documents should live. This is an initial stab at describing what might be reasonable "defaults," given our current family of forums and repositories. It also copies some of the discussion about public vs. private content from https://github.com/artsy/README/issues/2.

Closes https://github.com/artsy/README/issues/105.