### PR TITLE
Add Mentor to on-boarding template

### DIFF
--- a/.github/ISSUE_TEMPLATE/engineering-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/engineering-onboarding.md
@@ -2,6 +2,7 @@
 name: Engineering Onboarding
 about: A list of things to do to become familiar with how our engineering team operates.
 ---
+Mentor: <PICK A MENTOR>
 
 ## Your first day
 


### PR DESCRIPTION
# Problem
Currently it's not obvious who is the mentor for new employees during on-boarding.

# Solution
Mention the mentor (and kind of remind to pick one) in the issue template.

  