### PR TITLE
Adds FE iOS practice updates to standup docs

### DIFF
--- a/events/open-standup.md
+++ b/events/open-standup.md
@@ -63,6 +63,7 @@ _Hiring Updates_
 _Practice Updates_
 
 - Front-End: 
+- Front-End iOS: 
 - Platform: 
 - Data: 
 


### PR DESCRIPTION
We have a practice updates section, but the FrontEnd iOS Practice was absent from the list.