### PR TITLE
Add a note for the resolution step to the RFC template

### DIFF
--- a/.github/ISSUE_TEMPLATE/rfc.md
+++ b/.github/ISSUE_TEMPLATE/rfc.md
@@ -25,3 +25,7 @@ Other than that, we can continue to build up a global list of words to ignore.
 ## Additional Context:
 
 You can see our discussion [in slack here](/link/to/slack.com)
+
+## How is this RFC resolved?
+
+A PR to peril-settings adding the check


### PR DESCRIPTION
Sometimes it can be tricky for folks who didn't write the RFC.to know what it takes to resolve an RFC, adding this to the template should make it easier for us to figure it out and state upfront what the end-goal is.