### PR TITLE
Adds Front-End iOS Practice docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/engineering-onboarding.md
+++ b/.github/ISSUE_TEMPLATE/engineering-onboarding.md
@@ -2,6 +2,7 @@
 name: Engineering Onboarding
 about: A list of things to do to become familiar with how our engineering team operates.
 ---
+
 Mentor: <PICK A MENTOR>
 
 ## Your first day
@@ -10,7 +11,8 @@ _Goal: I’ve met my manager and some members of the engineering team (over lunc
 google (artsymail), 1Password, and know how to use the coffee machine._
 
 - [ ] Add a cool pic of yourself to Slack and Jira
-- [ ] Say hi in the [onboarding-eng](https://artsy.slack.com/messages/CCC37HXE0) slack channel and give BLANK a :wave: as they are the most recently onboarded person.
+- [ ] Say hi in the [onboarding-eng](https://artsy.slack.com/messages/CCC37HXE0) slack channel and give BLANK a
+      :wave: as they are the most recently onboarded person.
 
 ## Your first week
 
@@ -85,16 +87,16 @@ _Remember to review *all* setup scripts before executing them :)_
       [staging environment](https://github.com/artsy/gravity/blob/master/doc/StagingEnvironment.md).
 - [ ] Scan our list of preferred technologies. Dig in where necessary.
   - [ ] [Front-end technologies](https://github.com/artsy/README/blob/master/practices/front-end.md)
+  - [ ] [Front-end iOS technologies](https://github.com/artsy/README/blob/master/practices/front-end-ios.md)
   - [ ] [Back-end/Platform technologies](https://github.com/artsy/README/blob/master/practices/platform.md)
-  - [ ] iOS/React Native? #TODO
 - [ ] Reading: [Best of Our Blog](https://github.com/artsy/README/blob/master/resources/blog.md)
 - [ ] Reading:
       [Internal and external tech learning resources](https://github.com/artsy/README/blob/master/resources/tech-learning.md)
 - [ ] Watch some of our [Lunch & Learns](https://github.com/artsy/README/blob/master/resources/lnl.md)
 - [ ] Join the [#incidents](https://artsy.slack.com/messages/front-end-ios/) slack channel and scan through some
       recent threads
-- [ ] Read the [support doc](https://github.com/artsy/README/blob/master/playbooks/support#readme) about how support
-      incidents are handled by our on-call rotation
+- [ ] Read the [support doc](https://github.com/artsy/README/blob/master/playbooks/support#readme) about how
+      support incidents are handled by our on-call rotation
 - [ ] On-call onboarding #TODO
 
 #### Personal:

--- a/practices/README.md
+++ b/practices/README.md
@@ -7,6 +7,7 @@ which come together regularly to discuss.
 <!-- start_toc -->
 | Doc | Overview |
 |--|--|
+| [The Front-End iOS Practice](/practices/front-end-ios.md#readme) | How does Artsy make iOS Software? |
 | [The Front-End Practice](/practices/front-end.md#readme) | What do folks with a front-end focus do? |
 | [The history of practices at Artsy](/practices/history.md#readme) | How did we get to where we are |
 | [The Platform Practice](/practices/platform.md#readme) | What do folks with a platform focus do? |

--- a/practices/front-end-ios.md
+++ b/practices/front-end-ios.md
@@ -1,0 +1,78 @@
+---
+title: The Front-End iOS Practice
+description: How does Artsy make iOS Software?
+---
+
+## Practice Information
+
+The Front-End iOS Practice is distinct from the Front-End practice at Artsy; although there is significant overlap
+between the two, there are some things that are necessarily very different when building iOS software that it
+warrants an iOS practice. Those things include:
+
+- Much of our code is written in Objective-C and Swift, which aren't commonly used within Artsy Engineering.
+- Testing is different from other Artsy systems (Front-End and Platform practices test on staging; we test in
+  betas).
+- Deploying is different from other Artsy systems (Front-End and Platform practices promote from staging to
+  production; we cut betas and submit to Apple for App Store approval).
+- Long-term maintenance is different (Front-End and Platform practices deploy code to hardware they control and can
+  patch easily; we deploy code to hardware our users control and can't guarantee upgrading at all, so we have to
+  anticipate how iOS code will continue to operate in production for _years_).
+
+We do have a lot in common with the [Front-End Practice](./front-end.md):
+
+- Large parts of our codebase are written in the [Artsy Omakase](./front-end.md#the-artsy-omakase).
+- Our React/Native apps share [a common design system](https://github.com/artsy/palette/).
+- We're all solving problems for Artsy.
+
+We also have a lot of non-iOS engineers contributing to our React Native app. Part of the Front-End iOS Practice,
+then, is to support Front-End engineers contributing to our iOS projects (mostly via React Native, but
+[sometimes in native code](http://artsy.github.io/blog/2018/06/15/cocoapods-keys-react-native/)).
+
+## Team Information
+
+There are two important Slack groups:
+
+- **@ios-front-enders** Engineers who work on Artsy's iOS codebases in a native capacity.
+- **@app-release-team** The
+  [iOS App Quality Team 🔒](https://www.notion.so/artsy/Artsy-iOS-App-Quality-Team-58b9b55f52484000b9689edd809e7016)
+  is a team of one each Designer, Product Manager, and Engineer who help ensure the
+  [Artsy iOS app](http://iphone.artsy.net)'s quality.
+
+### Team Goals
+
+Our goals are the same as the [Front-End Practice goals](./front-end.md#team-goals), but with a focus on supporting
+iOS software at Artsy. That means we have the following additional goals:
+
+- Build tools and systems to help non-iOS engineers contribute to Artsy iOS software using React Native.
+- Help our colleagues understand the differences between building iOS software and web software.
+
+### Logistics
+
+Each iOS app at Artsy is deployed according to its own unique needs. See their repos for deployment instructions.
+
+### Our Technologies
+
+Initially, Artsy apps were built with Objective-C. Then Swift was announced in 2014, and
+[we tried it](http://artsy.github.io/blog/2017/02/05/Retrospective-Swift-at-Artsy/) but have ultimately
+[settled on React Native](http://artsy.github.io/blog/2018/03/17/two-years-of-react-native/). We will still use
+Objective-C and Swift for the foreseeable future, and native code will likely always make sense for parts of our
+app (notably, [the Augmented Reality feature](http://artsy.github.io/blog/2018/03/18/ar/) and the animation-driven
+[Live Auctions Integration](http://artsy.github.io/blog/2016/08/09/the-tech-behind-live-auction-integration/#The.iOS.native.app:.Eigen),
+user interface). New features are being built using React Native; the remaining native parts of our main app are
+[listed here 🔒](https://www.notion.so/artsy/Eigen-migration-to-React-Native-54dda83b023b4cb4965a8defdae9687f) with
+a decisions and priorities for switching them to React Native. We have no plans at this time to rewrite our
+native-only projects in React Native.
+
+### Artsy iOS Apps
+
+Artsy has the following iOS applications, which are all open source.
+
+- [Eigen](https://github.com/artsy/eigen) is Artsy's main iOS app. (Objective-C, Swift)
+  - [Emission](https://github.com/artsy/emission) is this app's React Native component library (see
+    [this post](http://artsy.github.io/blog/2018/04/17/making-a-components-pod/)). (TypeScript)
+- [Energy](https://github.com/artsy/energy) is Artsy's partner app. (Objective-C)
+- [Eidolon](https://github.com/artsy/eidolon) is Artsy's auctions kiosk. (Swift)
+- [Emergence](https://github.com/artsy/emergence) is Artsy's Apple TV app. (Swift)
+
+All Artsy iOS codebases start with the letter `e`, but not all Artsy codebases that start with the letter `e` are
+iOS ([example](https://github.com/artsy/exchange)).

--- a/practices/front-end-ios.md
+++ b/practices/front-end-ios.md
@@ -35,7 +35,7 @@ There are two important Slack groups:
 - **@ios-front-enders** Engineers who work on Artsy's iOS codebases in a native capacity.
 - **@app-release-team** The
   [iOS App Quality Team 🔒](https://www.notion.so/artsy/Artsy-iOS-App-Quality-Team-58b9b55f52484000b9689edd809e7016)
-  is a team of one each Designer, Product Manager, and Engineer who help ensure the
+  is a focused team of one Designer, one Product Manager, and one Engineer who help ensure the
   [Artsy iOS app](http://iphone.artsy.net)'s quality.
 
 ### Team Goals
@@ -48,7 +48,8 @@ iOS software at Artsy. That means we have the following additional goals:
 
 ### Logistics
 
-Each iOS app at Artsy is deployed according to its own unique needs. See their repos for deployment instructions.
+Each iOS app at Artsy is deployed according to its own unique needs. See their repos (listed
+[below](#artsy-ios-apps)) for deployment instructions.
 
 ### Our Technologies
 
@@ -59,8 +60,8 @@ Objective-C and Swift for the foreseeable future, and native code will likely al
 app (notably, [the Augmented Reality feature](http://artsy.github.io/blog/2018/03/18/ar/) and the animation-driven
 [Live Auctions Integration](http://artsy.github.io/blog/2016/08/09/the-tech-behind-live-auction-integration/#The.iOS.native.app:.Eigen),
 user interface). New features are being built using React Native; the remaining native parts of our main app are
-[listed here 🔒](https://www.notion.so/artsy/Eigen-migration-to-React-Native-54dda83b023b4cb4965a8defdae9687f) with
-a decisions and priorities for switching them to React Native. We have no plans at this time to rewrite our
+[listed here 🔒](https://www.notion.so/artsy/Eigen-migration-to-React-Native-54dda83b023b4cb4965a8defdae9687f)
+alongside decisions and priorities for switching them to React Native. We have no plans at this time to rewrite our
 native-only projects in React Native.
 
 ### Artsy iOS Apps

--- a/practices/front-end-ios.md
+++ b/practices/front-end-ios.md
@@ -38,6 +38,9 @@ There are two important Slack groups:
   is a focused team of one Designer, one Product Manager, and one Engineer who help ensure the
   [Artsy iOS app](http://iphone.artsy.net)'s quality.
 
+The Front-End iOS Practice meetings every two weeks; meeting notes are
+[available in Notion](https://www.notion.so/artsy/Front-End-iOS-ecc07763bfd04a848c74107dde3ec6dc).
+
 ### Team Goals
 
 Our goals are the same as the [Front-End Practice goals](./front-end.md#team-goals), but with a focus on supporting


### PR DESCRIPTION
This adds docs for the Front-End iOS Practice, addressing the biggest question: why do we have a separate iOS practice? I followed the format of the [Front-End Practice docs](https://github.com/artsy/README/blob/master/practices/front-end.md) and added what made sense for us.

I'm going to leave this PR unassigned and leave it open for a while, RFC-style. Take your time providing feedback.