### PR TITLE
Revise links to point to in-repository project list

### DIFF
--- a/onboarding/engineering-introduction.md
+++ b/onboarding/engineering-introduction.md
@@ -6,14 +6,24 @@ description: A brief introduction
 ## Welcome Logistics
 
 ### Work hours
-Depends on the person/where they are located! We try to schedule meetings at times that are amenable to people being remote (from Amsterdam to Seattle on the engineering team), so they'll usually happen in the middle of the day EST.
 
-Ask your mentor/manager what their general work hours are. Artsy has no policy around this, so use your judgment and be open with your team about when you expect to be available.
+Depends on the person/where they are located! We try to schedule meetings at times that are amenable to people
+being remote (from Amsterdam to Seattle on the engineering team), so they'll usually happen in the middle of the
+day EST.
+
+Ask your mentor/manager what their general work hours are. Artsy has no policy around this, so use your judgment
+and be open with your team about when you expect to be available.
 
 ### Vacation
-Artsy has an open vacation policy. This doesn't mean "don't take vacation." _Please take time off._ Most people take off for bank holidays.
 
-Join the [Design/Product OOO](https://calendar.google.com/calendar/embed?src=artsymail.com_gl81jptn59gjfv1kg0fer1i4jo%40group.calendar.google.com&ctz=America%2FNew_York) calendar and use that to set when you know you'll be out of the office (you don't generally need to post remote work here unless it's out of the ordinary and would benefit from wider communication i.e. you'll be working for a month from somewhere else).
+Artsy has an open vacation policy. This doesn't mean "don't take vacation." _Please take time off._ Most people
+take off for bank holidays.
+
+Join the
+[Design/Product OOO](https://calendar.google.com/calendar/embed?src=artsymail.com_gl81jptn59gjfv1kg0fer1i4jo%40group.calendar.google.com&ctz=America%2FNew_York)
+calendar and use that to set when you know you'll be out of the office (you don't generally need to post remote
+work here unless it's out of the ordinary and would benefit from wider communication i.e. you'll be working for a
+month from somewhere else).
 
 ### Chat
 
@@ -22,7 +32,9 @@ own channels. For more information on our usage of Slack, see [`/culture/slack.m
 
 ### Events
 
-See the [events list](/events) for descriptions of our recurring, engineering-wide events. Look at the [Engineering - Open Meetings calendar](https://calendar.google.com/calendar/r?cid=YXJ0c3ltYWlsLmNvbV9nODFpbzRhOThkZHZuMWloMWEzbG0yb2NkNEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t) to see when they are scheduled and feel free to add yourself to any (or just show up).
+See the [events list](/events) for descriptions of our recurring, engineering-wide events. Look at the
+[Engineering - Open Meetings calendar](https://calendar.google.com/calendar/r?cid=YXJ0c3ltYWlsLmNvbV9nODFpbzRhOThkZHZuMWloMWEzbG0yb2NkNEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t)
+to see when they are scheduled and feel free to add yourself to any (or just show up).
 
 We have an engineering team-wide standup on _Mondays at 11:30 a.m. Eastern_ (virtual:
 [https://zoom.us/my/artsyclassroom](https://zoom.us/my/artsyclassroom)) where we:
@@ -38,17 +50,17 @@ The standup is fully documented [here](/events/open-standup.md).
 ### Getting Help
 
 - **Slack:** If you know what team could potentially help you, browse the channels in Slack to find the most
-  relevant place to ask your question. If you aren't sure, [#dev](https://artsy.slack.com/messages/dev) 🔒 is a good
-  place to start.
+  relevant place to ask your question. If you aren't sure, [#dev](https://artsy.slack.com/messages/dev) 🔒 is a
+  good place to start.
 - **Ask Your Neighbor:** Everyone is friendly. Don't hesitate to reach out to the people around you for even the
   most basic of questions.
-- **Check Atlas:** Turns out a lot of common questions are available in [atlas.artsy.net](http://atlas.artsy.net) 🔒.
+- **Check Atlas:** Turns out a lot of common questions are available in [atlas.artsy.net](http://atlas.artsy.net)
+  🔒.
 
 ## Who we are
 
-Some team members have backgrounds in art, but of course not all.
-[/resources/art.md](/resources/art.md) has some useful links if you want to read more about the art
-world, or keep up with the latest news.
+Some team members have backgrounds in art, but of course not all. [/resources/art.md](/resources/art.md) has some
+useful links if you want to read more about the art world, or keep up with the latest news.
 
 ### Open Source Culture + Projects
 
@@ -64,17 +76,20 @@ Artsy and their reasons behind open-sourcing our [mobile app](https://github.com
 Orta also wrote a blog post on the
 [mechanics behind open-sourcing Eigen](https://artsy.github.io/blog/2015/04/28/how-we-open-sourced-eigen/).
 
-
 ## Our stack/technologies
 
 ### GitHub
 
-Artsy stores source code on [GitHub](https://github.com/artsy). Make sure you have an account and are part of the Artsy organization. If you can't visit [this page](https://github.com/artsy/gravity) 🔒, then you don’t have the right access. Your mentor can get you sorted out.
+Artsy stores source code on [GitHub](https://github.com/artsy). Make sure you have an account and are part of the
+Artsy organization. If you can't visit [this page](https://github.com/artsy/gravity) 🔒, then you don’t have the
+right access. Your mentor can get you sorted out.
 
-Our projects use physics terms as code names, starting with [Gravity](https://github.com/artsy/gravity) 🔒 (inspired
-by [Zachary Coffin's "Temple of Gravity"](http://www.zacharycoffin.com/work/temple-of-gravity)).
+Our projects use physics terms as code names, starting with [Gravity](https://github.com/artsy/gravity) 🔒
+(inspired by [Zachary Coffin's "Temple of Gravity"](http://www.zacharycoffin.com/work/temple-of-gravity)).
 
-See the [engineering projects map](https://github.com/artsy/potential/wiki/Project-List) 🔒 for a comprehensive list of our (many) repos and who owns them. It can be a bit overwhelming, so here are some important ones:
+See the [engineering projects map](https://github.com/artsy/potential/blob/master/Project-List.md) 🔒 for a
+comprehensive list of our (many) repos and who owns them. It can be a bit overwhelming, so here are some important
+ones:
 
 - [Gravity](https://github.com/artsy/gravity) 🔒: Artsy's main API
 - [Force](https://github.com/artsy/force): Artsy web site ([www.artsy.net](https://www.artsy.net))
@@ -105,7 +120,8 @@ See [data](https://github.com/artsy/potential/blob/master/data/README.md) 🔒.
 
 ## How We Work
 
-The engineering team [playbooks](/playbooks#readme) discuss why we make the technical and non-technical decisions we do.
+The engineering team [playbooks](/playbooks#readme) discuss why we make the technical and non-technical decisions
+we do.
 
 ### Development Environments
 
@@ -138,8 +154,8 @@ As all of our code is housed on GitHub, we make contributions through
 [pull requests](https://artsy.github.io/blog/2012/01/29/how-art-dot-sy-uses-github-to-build-art-dot-sy/).
 
 Read more in [the engineer workflow playbook](/playbooks/engineer-workflow.md#readme) or see this
-[step-by-step guide](https://github.com/artsy/potential/blob/master/github/workflow.md) 🔒. If you're unfamiliar with
-Git, check out this [short tutorial](https://try.github.io) on basic git commands (such as `git status`,
+[step-by-step guide](https://github.com/artsy/potential/blob/master/github/workflow.md) 🔒. If you're unfamiliar
+with Git, check out this [short tutorial](https://try.github.io) on basic git commands (such as `git status`,
 `git commit`, and `git push`).
 
 ### Deploying

--- a/playbooks/engineer-workflow.md
+++ b/playbooks/engineer-workflow.md
@@ -88,7 +88,7 @@ Who should you assign? You can ask yourself the following questions as a rubric:
 - Do I know who this PR affects and/or someone familiar with the codebase? Assign them.
 - Does the project have point persons listed in the README? Assign one of them.
 - Is the project targeted by your changes owned by a team in the
-  [Project list](https://github.com/artsy/potential/wiki/Project-List)? Assign someone on that team.
+  [Project list](https://github.com/artsy/potential/blob/master/Project-List.md)? Assign someone on that team.
 - Does GitHub suggest any reviewers, based on git blame data? Consider one of them.
 
 If none of these prompts yields a potential assignee, it's worth bringing up in Slack.
@@ -171,7 +171,7 @@ compromises in pursuit of a healthful state.
 ## Documentation
 
 Teams and projects change to adapt to business needs. Code repositories come and go as well, but usually more
-slowly. The [project map](https://github.com/artsy/potential/wiki/Project-List) 🔒 aims to list all the
+slowly. The [project map](https://github.com/artsy/potential/blob/master/Project-List.md) 🔒 aims to list all the
 repositories that Artsy maintains, organized by the responsible team.
 
 Product team [slack channels](https://artsy.slack.com) 🔒 are usually the first stop for help in a given team's

--- a/playbooks/support/README.md
+++ b/playbooks/support/README.md
@@ -19,7 +19,8 @@ which is determined at least a month in advance (giving people ample time to mak
 
 The schedule is configured on the
 [Engineering On-Call calendar](https://calendar.google.com/calendar/embed?src=artsymail.com_nolej2muchgbpne9etkf7qfet8%40group.calendar.google.com&ctz=America%2FNew_York).
-Trading shifts (because of vacations, obligations, etc.) is encouraged as long as the calendar is kept up-to-date. Please address any scheduling issues as early as possible.
+Trading shifts (because of vacations, obligations, etc.) is encouraged as long as the calendar is kept up-to-date.
+Please address any scheduling issues as early as possible.
 
 During work hours, on-call engineers are responsible for responding to issues in
 [the #incidents slack channel](https://artsy.slack.com/messages/C9RK0BLEP/) 🔒 in a timely fashion. Outside of work
@@ -44,19 +45,23 @@ ongoing sprint and team activities.
 - Look out for trends and create bugs (in the
   [universal bug backlog](https://artsyproduct.atlassian.net/secure/RapidBoard.jspa?rapidView=34)) where necessary
   that can be triaged into individual teams' sprints by a PM.
-- If the issue is obviously a non-incident, take the time to educate the reporter on the desired process (see the [examples](#examples) below). You may point them to the [Guide to Reporting Bugs](https://www.notion.so/artsy/Guide-to-reporting-bugs-cc25e1ff41194228b476c4963c646817) doc in Notion which describes this in a general way.
+- If the issue is obviously a non-incident, take the time to educate the reporter on the desired process (see the
+  [examples](#examples) below). You may point them to the
+  [Guide to Reporting Bugs](https://www.notion.so/artsy/Guide-to-reporting-bugs-cc25e1ff41194228b476c4963c646817)
+  doc in Notion which describes this in a general way.
 
 #### 2. Investigate and address critical issues
 
-- Acknowledge the issue in slack (escalate to the [#incidents](https://artsy.slack.com/messages/C9RK0BLEP/) 🔒 channel
-  if not already there)
+- Acknowledge the issue in slack (escalate to the [#incidents](https://artsy.slack.com/messages/C9RK0BLEP/) 🔒
+  channel if not already there)
 - **Use slack threads** to keep the channel and its notifications focused, and allow others to monitor for new
   incidents at a glance.
 - Investigate the issue individually and as a pair.
 - Judge the severity (based on intuition or a helpful PM/business owner)
 - Fix if possible using [accumulated playbooks (wiki)](https://github.com/artsy/potential/wiki) 🔒.
 - If unable to fix using shared resources, contact the relevant [point-person](#point-people) for help and pair
-  with them on a fix. Be sure to contribute lessons back to shared documentation. **You are not expected to know the ins and outs of every system, so don't hesitate to involve the wider team.**
+  with them on a fix. Be sure to contribute lessons back to shared documentation. **You are not expected to know
+  the ins and outs of every system, so don't hesitate to involve the wider team.**
 - Point-people should only be contacted during off-hours for outages that the on-call engineers are unable to
   diagnose.
 - Share any applicable work-arounds or talking points in the thread to unblock teammates or partners.
@@ -65,7 +70,8 @@ ongoing sprint and team activities.
 - If the issue was mis-reported and doesn't require a timely fix, surface to PM/add to backlog for tracking by the
   appropriate team
 
-**Note:** You are not responsible for fixing all of the bugs that you find. Most problems that require a coding change should be addressed by the relevant team.
+**Note:** You are not responsible for fixing all of the bugs that you find. Most problems that require a coding
+change should be addressed by the relevant team.
 
 #### 3. Track incidents' status
 
@@ -94,8 +100,8 @@ Tips for using the incidents Trello:
 
 ## Handing-off to a new shift
 
-After [engineering-wide stand-up](/events/open-standup.md#dev-team-standup-at-artsy) is a good time for
-the coming and going on-call engineers to sync up and hand off any ongoing responsibilities. Customarily we:
+After [engineering-wide stand-up](/events/open-standup.md#dev-team-standup-at-artsy) is a good time for the coming
+and going on-call engineers to sync up and hand off any ongoing responsibilities. Customarily we:
 
 - Update the "Resolved" column in [the Incidents trello](https://trello.com/b/sZQ9qpVo/incidents) with the past
   week's dates and create a new one for the upcoming shift.
@@ -138,7 +144,7 @@ You can find the point people in the [Potential Wiki](https://github.com/artsy/p
 
 ### Artsy domain information
 
-- [Engineering projects map](https://github.com/artsy/potential/wiki/Project-List) 🔒
+- [Engineering projects map](https://github.com/artsy/potential/blob/master/Project-List.md) 🔒
 - [Monitoring](https://github.com/artsy/potential/blob/master/platform/Monitoring.md) 🔒
 - [Domain Models](https://github.com/artsy/potential/blob/master/platform/DomainModels.md) 🔒
 - [Status Page](http://status.artsy.net/)
@@ -146,13 +152,17 @@ You can find the point people in the [Potential Wiki](https://github.com/artsy/p
 ## Special cases
 
 ### Team members who leave
-If someone who is scheduled to be on-call ends up leaving the engineering team (by moving to a different team or leaving Artsy altogether), it is their (previous) manager's responsibility to cover their shift. The manager will either take the shift themselves or, if they are unavailable, find someone who can.
+
+If someone who is scheduled to be on-call ends up leaving the engineering team (by moving to a different team or
+leaving Artsy altogether), it is their (previous) manager's responsibility to cover their shift. The manager will
+either take the shift themselves or, if they are unavailable, find someone who can.
 
 ### Holidays
 
 Holidays (such as labor day in the US) should be treated as if they are weekends.
 
-For the week between Christmas and New Years, we operate outside of normal shifts. This week is broken into 2-day shifts that individuals can volunteer for.
+For the week between Christmas and New Years, we operate outside of normal shifts. This week is broken into 2-day
+shifts that individuals can volunteer for.
 
 ## Examples
 

--- a/practices/platform.md
+++ b/practices/platform.md
@@ -64,8 +64,8 @@ Some projects leverage [Docker](https://www.docker.com/) and our [Kubernetes](ht
 
 [Gravity](https://github.com/artsy/gravity) was Artsy’s original monolith and now hosts the main API. Follow the
 [Gravity docs](https://github.com/artsy/gravity/blob/master/doc/GettingStarted.md) to get set up, or this
-introduction:
-[Working with Gravity](https://github.com/artsy/potential/blob/master/platform/WorkingWithGravity.md) 🔒.
+introduction: [Working with Gravity](https://github.com/artsy/potential/blob/master/platform/WorkingWithGravity.md)
+🔒.
 
 ### Major systems:
 
@@ -83,5 +83,5 @@ introduction:
 
 In general, see project READMEs for project details including links, CI, deployment instructions, and point-people.
 
-The full [project list](https://github.com/artsy/potential/wiki/Project-list) 🔒
-has a more exhaustive list of Artsy's systems.
+The full [project list](https://github.com/artsy/potential/blob/master/Project-List.md) 🔒 has a more exhaustive
+list of Artsy's systems.


### PR DESCRIPTION
Depends on https://github.com/artsy/potential/pull/229.

All I did was replace a few links. The other changes are due to the automated `prettier` run. I have no idea why it seems to have different output than for previous committers.