### PR TITLE
Move README suggestions to documentation playbook

### DIFF
--- a/onboarding/README.md
+++ b/onboarding/README.md
@@ -17,7 +17,7 @@ More onboarding resources:
 |--|--|
 | [Engineering Team Introduction](/onboarding/engineering-introduction.md#readme) | A brief introduction |
 | [Onboarding Responsibilities for Managers of New Hires](/onboarding/managers.md#readme) | Things for managers to remember during the early days of onboarding |
-| [Mentoring](/onboarding/mentors.md#readme) | Guidelines for effective mentorship |
+| [Onboarding Responsibilities for Mentors of New Hires](/onboarding/mentors.md#readme) | How to be an effective mentor of a new hire |
 | [Onboarding for New Hires](/onboarding/new-hires.md#readme) | Your first steps to being productive |
 | [Sprint Rotation](/onboarding/sprint-rotation.md#readme) | What is the sprint rotation and how does it work? |
 <!-- end_toc -->

--- a/playbooks/documentation.md
+++ b/playbooks/documentation.md
@@ -23,6 +23,23 @@ Other repo-specific interactions such as presenting the rationale for a design o
 leverage the built-in mechanisms of [commit messages](/playbooks/engineer-workflow.md#commits),
 [pull requests](/playbooks/engineer-workflow.md#pull-requests), and comments.
 
+### READMEs
+
+Project README files should provide enough context to understand and contribute to a project including:
+
+- High-level description of the project's use, as well as metadata including:
+- Development stage (development, beta, production, deprecated, retired...)
+- Links to hosting environment(s)
+- Links to GitHub repo(s)
+- Continuous integration and branching information
+- Deployment instructions
+- Who to contact for guidance
+- Any other relevant links
+- Instructions for setting up, testing, and contributing to the project
+- License (probably [MIT](https://opensource.org/licenses/MIT)) and copyright, if open source
+
+See a [recent example](https://github.com/artsy/impulse#impulse-) 🔒 as a template.
+
 ## Public versus private content
 
 When creating a repo, contributing a doc, or discussing in-progress work, consider whether it's appropriate for

--- a/playbooks/engineer-workflow.md
+++ b/playbooks/engineer-workflow.md
@@ -178,17 +178,5 @@ repositories that Artsy maintains, organized by the responsible team.
 Product team [slack channels](https://artsy.slack.com) 🔒 are usually the first stop for help in a given team's
 area of responsibility.
 
-Project README files should provide enough context to understand and contribute to a project including:
-
-- High-level description of the project's use, as well as metadata including:
-- Development stage (development, beta, production, deprecated, retired...)
-- Links to hosting environment(s)
-- Links to GitHub repo(s)
-- Continuous integration and branching information
-- Deployment instructions
-- Who to contact for guidance
-- Any other relevant links
-- Instructions for setting up, testing, and contributing to the project
-- License (probably [MIT](https://opensource.org/licenses/MIT)) and copyright, if open source
-
-See a [recent example](https://github.com/artsy/impulse#impulse-) 🔒 as a template.
+See the [documentation playbook](documentation.md) for a discussion of where to document systems, processes, and so
+on.


### PR DESCRIPTION
The recent documentation playbook seems like a better location for the README suggestions.