### PR TITLE
Update support document

### DIFF
--- a/playbooks/support/README.md
+++ b/playbooks/support/README.md
@@ -6,13 +6,6 @@
 - [Process Overview](#process-overview)
 - [On-Call Responsibilities](#on-call-responsibilities)
 - [Responding to an incident](#responding-to-an-incident)
-  - [Step 1: Alert](#step-1-alert)
-  - [Step 2: Raise](#step-2-raise)
-  - [Step 3: Assess](#step-3-assess)
-  - [Step 4: Address Incident](#step-4-address-incident)
-    - [Investigate --> Identify --> Escalate --> Fix](#investigate----identify----escalate----fix)
-    - [Communicate](#communicate)
-  - [Step 5: Resolve](#step-5-resolve)
 - [Severity of Incidents](#severity-of-incidents)
 - [Best practices](#best-practices)
 - [Handing-off to a new shift](#handing-off-to-a-new-shift)
@@ -45,18 +38,20 @@ sprints. See [below](#examples) for some common examples.
 ## Process Overview
 
 In order to ensure stability every week, **two** engineers will be "on-call." On a staggered rotating schedule
-which is determined at least a month in advance (giving people ample time to make changes if need-be).
+which is determined at least a month in advance (see [scheduling doc](scheduling.md)).
 
-The schedule is configured on the
-[Engineering On-Call calendar](https://calendar.google.com/calendar/embed?src=artsymail.com_nolej2muchgbpne9etkf7qfet8%40group.calendar.google.com&ctz=America%2FNew_York).
-Trading shifts (because of vacations, obligations, etc.) is encouraged as long as the calendar is kept up-to-date.
-Please address any scheduling issues as early as possible.
+On Mondays and Wednesdays, rotating on-call engineers sync up and hand off any ongoing responsibilities:
+
+- Review active and recent incidents [on Jira Ops][jira-ops-all-incidents]
+- Hand off any in-progress incident remediation tasks ([see responding doc](responding.md))
+
+[jira-ops-all-incidents]: https://artsyproduct.atlassian.net/projects/INCIDENT/incidents/all
+
+## On-Call Responsibilities
 
 During work hours, on-call engineers are responsible for responding to issues in
 [the #incidents slack channel](https://artsy.slack.com/messages/C9RK0BLEP/) 🔒 in a timely fashion. Outside of work
 hours, engineers are _only_ responsible for downtime issues.
-
-## On-Call Responsibilities
 
 While on-call, you are accountable for investigating and fixing timely issues, escalating to additional
 point-people and/or routing to team-specific backlogs where appropriate.
@@ -70,100 +65,7 @@ favorable timezones where appropriate.
 
 ## Responding to an incident
 
-### Step 1: Alert
-
-Incidents can be raised by automated or manual means. While on-call, you are responsible for being available to
-respond to these issues.
-
-- Monitor the [#incidents slack channel](https://artsy.slack.com/messages/C9RK0BLEP/) 🔒 for critical issues. This
-  is where urgent issues are raised, either manually or via automated alerts.
-- Monitor the [#alerts](https://artsy.slack.com/messages/C0HP61PUJ/) slack channel _during business/waking hours_.
-  These automated system alerts _may_ be the first sign of a problem but don't _necessarily_ warrant treatment as
-  immediate incidents. E.g., load-balancers may route around failing EC2 instances or auto-scaling may bring up
-  capacity in response to load.
-- If the issue is obviously a non-incident, take the time to educate the reporter on the desired process (see the
-  [examples](#examples) below). You may point them to the
-  [Guide to Reporting Bugs](https://www.notion.so/artsy/Guide-to-reporting-bugs-cc25e1ff41194228b476c4963c646817)
-  doc in Notion which describes this in a general way.
-
-### Step 2: Raise
-
-1. When an incident is raised in the channel or identified in another way, the on-call team first **tracks the
-   incident** by creating a ticket in [Jira Ops](https://artsyproduct.atlassian.net/projects/INCIDENT/incidents),
-   based on the information they know at that time. Some workflow steps:
-
-   - In the description on the ticket, link to the slack thread in #incidents or #alerts.
-   - Take your best guess at the other information, it can always be edited later.
-
-2. Using the slack integration on the Jira Ops ticket, create a new slack channel to discuss resolution.
-3. In the original slack thread in #incidents, put a link to the incident that was created and _direct engineers to
-   the newly created slack channel for discussing its resolution_.
-
-### Step 3: Assess
-
-1. A member of the on-call team marks the issue as **FIXING**. This person will be automatically assigned to the
-   issue. For the duration of the incident resolution, this person is responsible for _facilitation_. This may
-   involve pulling in other engineers to help solve the problem and delegating tasks like external communication to
-   the other on-call team member.
-2. Determine and update the [severity of the incident](<(#severity-of-incidents)>) by trying to reproduce the
-   problem and following up with stakeholders as-needed. It may be helpful to find answers to the following:
-
-   - How many people (or partners, etc.) does this affect?
-   - Have you been able to reproduce?
-   - Is this a new problem or something that we are aware of?
-
-3. If the reported incident does not qualify for an immediate response:
-   - Direct stakeholders in the slack thread to a product team’s channel to ensure that a Jira Issue is tracked for
-     this possible issue
-   - Link the Jira Ops ticket to any relevant bugs that are tracked (and create an additional one if necessary)
-   - Mark the ticket as **CANCELED**
-
-### Step 4: Address Incident
-
-#### Investigate --> Identify --> Escalate --> Fix
-
-Discuss the incident's resolution in the dedicated slack channel.
-
-- Fix if possible using [accumulated playbooks (wiki)](https://github.com/artsy/potential/wiki) 🔒.
-- If unable to fix using shared resources, contact the relevant [point-person](#point-people) for help and pair
-  with them on a fix. Be sure to contribute lessons back to shared documentation. **You are not expected to know
-  the ins and outs of every system, so don't hesitate to involve the wider team.**
-- Share any applicable work-arounds or talking points in the thread to unblock teammates or partners.
-- If you make an immediate fix but addressing the root cause requires further work, add the issue to the bug
-  backlog so it can be prioritized accordingly.
-
-**Note:** You are not responsible for fixing all of the bugs that you find. Most problems that require a coding
-change should be addressed by the relevant team.
-
-#### Communicate
-
-One of the on-call members handles internal and external communication for the incident.
-
-- #incidents is for non-on-call people to raise possible incidents or follow up (questions, etc.) about existing
-  threads.
-- Resolution happens exclusively in the dedicated slack channel associated with the Jira Ops ticket.
-- Meaningful updates, discoveries, or milestones (e.g. changes in availability or resolution) are added to the Jira
-  Ops ticket by the assignee.
-- Any incident with public impact should be communicated externally via the status page. Communication does not
-  have to be detailed. The most important thing is acknowledging issues and communicating progress towards a
-  resolution. Use the status page integration on the Jira Ops ticket for posting updates and resolutions.
-
-### Step 5: Resolve
-
-Incidents are resolved when the immediate issue has been mitigated. After that, the team needs to make sure all
-follow-up items are tracked and the Jira Ops ticket clearly reflects this state.
-
-1. Create any necessary follow-up tickets either in the bug backlog or a specific team’s project board. Link these
-   from within the Jira Ops ticket.
-2. Post any final updates to the Jira Ops ticket
-
-- Update timestamps
-- Mark the ticket as **RESOLVED**
-- Add any additional labels or metadata that may be relevant later
-
-3. Resolve any outstanding incidents on our status page via the integration on the Jira Ops ticket.
-4. If the incident was Critical, create a post mortem following the guidelines in our
-   [post_mortems repo](https://github.com/artsy/post_mortems).
+See the [responding doc](responding.md).
 
 ## Severity of Incidents
 
@@ -191,15 +93,6 @@ The following definitions are borrowed from
   - Improve shared tooling/monitoring/alerting
 
 ## Handing-off to a new shift
-
-After [engineering-wide stand-up](/events/open-standup.md#dev-team-standup-at-artsy) is a good time for the coming
-and going on-call engineers to sync up and hand off any ongoing responsibilities. Customarily we:
-
-- Review resolved and active items on the Incidents board, sharing anything the new team must know to handle them
-  or identifying any final action items for the departing team to fully resolve them (like creating Jira tickets,
-  releasing PRs, etc.).
-- Finally, the departing team should take this opportunity to update
-  [the accumulated playbooks](https://github.com/artsy/potential/wiki) 🔒 with any last lessons.
 
 ## Helpful Resources and Playbooks
 

--- a/playbooks/support/responding.md
+++ b/playbooks/support/responding.md
@@ -1,0 +1,97 @@
+# Responding to an incident
+
+## Step 1: Alert
+
+Incidents can be raised by automated or manual means. While on-call, you are responsible for being available to
+respond to these issues.
+
+- Monitor the [#incidents slack channel](https://artsy.slack.com/messages/C9RK0BLEP/) 🔒 for critical issues. This
+  is where urgent issues are raised, either manually or via automated alerts.
+- Monitor the [#alerts](https://artsy.slack.com/messages/C0HP61PUJ/) slack channel _during business/waking hours_.
+  These automated system alerts _may_ be the first sign of a problem but don't _necessarily_ warrant treatment as
+  immediate incidents. E.g., load-balancers may route around failing EC2 instances or auto-scaling may bring up
+  capacity in response to load.
+- If the issue is obviously a non-incident, take the time to educate the reporter on the desired process (see the
+  [examples](#examples) below). You may point them to the
+  [Guide to Reporting Bugs](https://www.notion.so/artsy/Guide-to-reporting-bugs-cc25e1ff41194228b476c4963c646817)
+  doc in Notion which describes this in a general way.
+
+## Step 2: Raise
+
+1. When an incident is raised in the channel or identified in another way, the on-call team first **tracks the
+   incident** by creating a ticket in [Jira Ops](https://artsyproduct.atlassian.net/projects/INCIDENT/incidents),
+   based on the information they know at that time. Some workflow steps:
+
+   - In the description on the ticket, link to the slack thread in #incidents or #alerts.
+   - Take your best guess at the other information, it can always be edited later.
+
+2. Using the slack integration on the Jira Ops ticket, create a new slack channel to discuss resolution.
+3. In the original slack thread in #incidents, put a link to the incident that was created and _direct engineers to
+   the newly created slack channel for discussing its resolution_.
+
+## Step 3: Assess
+
+1. A member of the on-call team marks the issue as **FIXING**. This person will be automatically assigned to the
+   issue. For the duration of the incident resolution, this person is responsible for _facilitation_. This may
+   involve pulling in other engineers to help solve the problem and delegating tasks like external communication to
+   the other on-call team member.
+2. Determine and update the [severity of the incident](<(#severity-of-incidents)>) by trying to reproduce the
+   problem and following up with stakeholders as-needed. It may be helpful to find answers to the following:
+
+   - How many people (or partners, etc.) does this affect?
+   - Have you been able to reproduce?
+   - Is this a new problem or something that we are aware of?
+
+3. If the reported incident does not qualify for an immediate response:
+   - Direct stakeholders in the slack thread to a product team’s channel to ensure that a Jira Issue is tracked for
+     this possible issue
+   - Link the Jira Ops ticket to any relevant bugs that are tracked (and create an additional one if necessary)
+   - Mark the ticket as **CANCELED**
+
+## Step 4: Address Incident
+
+**Investigate --> Identify --> Escalate --> Fix**
+
+Discuss the incident's resolution in the dedicated slack channel.
+
+- Fix if possible using [accumulated playbooks (wiki)](https://github.com/artsy/potential/wiki) 🔒.
+- If unable to fix using shared resources, contact the relevant [point-person](#point-people) for help and pair
+  with them on a fix. Be sure to contribute lessons back to shared documentation. **You are not expected to know
+  the ins and outs of every system, so don't hesitate to involve the wider team.**
+- Share any applicable work-arounds or talking points in the thread to unblock teammates or partners.
+- If you make an immediate fix but addressing the root cause requires further work, add the issue to the bug
+  backlog so it can be prioritized accordingly.
+
+**Note:** You are not responsible for fixing all of the bugs that you find. Most problems that require a coding
+change should be addressed by the relevant team.
+
+### Communicate
+
+One of the on-call members handles internal and external communication for the incident.
+
+- #incidents is for non-on-call people to raise possible incidents or follow up (questions, etc.) about existing
+  threads.
+- Resolution happens exclusively in the dedicated slack channel associated with the Jira Ops ticket.
+- Meaningful updates, discoveries, or milestones (e.g. changes in availability or resolution) are added to the Jira
+  Ops ticket by the assignee.
+- Any incident with public impact should be communicated externally via the status page. Communication does not
+  have to be detailed. The most important thing is acknowledging issues and communicating progress towards a
+  resolution. Use the status page integration on the Jira Ops ticket for posting updates and resolutions.
+
+## Step 5: Resolve
+
+Incidents are resolved when the immediate issue has been mitigated. After that, the team needs to make sure all
+follow-up items are tracked and the Jira Ops ticket clearly reflects this state.
+
+1. Create any necessary follow-up tickets either in the bug backlog or a specific team’s project board. Link these
+   from within the Jira Ops ticket.
+2. Post any final updates to the Jira Ops ticket
+
+- Update timestamps
+- Mark the ticket as **RESOLVED**
+- Add any additional labels or metadata that may be relevant later
+
+3. Resolve any outstanding incidents on our status page via the integration on the Jira Ops ticket.
+4. If the incident was Critical, create a post mortem following the guidelines in our
+   [post_mortems repo](https://github.com/artsy/post_mortems).
+5. Update relevant [playbooks](https://github.com/artsy/potential/wiki) 🔒 with any lessons.

--- a/playbooks/support/scheduling.md
+++ b/playbooks/support/scheduling.md
@@ -1,32 +1,59 @@
-# How to Schedule an On-Call Round
+# Scheduling
 
-A month before the next round of on-call is slated to begin (can check when the current round ends to verify this timeline), we being scheduling the next round.
+The schedule is configured on the [Engineering On-Call calendar][]. Trading shifts (because of vacations,
+obligations, etc.) is encouraged as long as the calendar is kept up-to-date. Please address any scheduling issues
+as early as possible.
+
+A month before the next round of on-call is slated to begin (can check when the current round ends to verify this
+timeline), we being scheduling the next round.
+
+[engineering on-call calendar]:
+  https://calendar.google.com/calendar/embed?src=artsymail.com_nolej2muchgbpne9etkf7qfet8%40group.calendar.google.com&ctz=America%2FNew_York
 
 ## Steps for Scheduling On-Call
-1. Generate a list of current engineers. This should include everyone who started before the next round is supposed to begin. (Can use team.artsy.net as a reference)
-2. Clone the [Notion template](https://www.notion.so/artsy/Template-On-Call-Scheduling-20079a4d56634b29bebfa80a6813c800) and generate a list of shift dates
-  - Dates should stagger where possible (so shifts go Monday --> Monday and Wednesday --> Wednesday)
-  - If the round covers the December/January holidays, segment the period into 2-day shifts. Tag them as "Holiday Volunteer Shift"
-  - Add tags for shifts that cover notable holidays (i.e. "American Thanksgiving")
+
+1. Generate a list of current engineers. This should include everyone who started before the next round is supposed
+   to begin. (Can use team.artsy.net as a reference)
+2. Clone the
+   [Notion template](https://www.notion.so/artsy/Template-On-Call-Scheduling-20079a4d56634b29bebfa80a6813c800) and
+   generate a list of shift dates
+
+- Dates should stagger where possible (so shifts go Monday --> Monday and Wednesday --> Wednesday)
+- If the round covers the December/January holidays, segment the period into 2-day shifts. Tag them as "Holiday
+  Volunteer Shift"
+- Add tags for shifts that cover notable holidays (i.e. "American Thanksgiving")
+
 3. Identify any exceptions/special cases and address them. These may include:
-  - People who doubled-up the last round (should be left out of this round)
-  - People who have very recently started (as a courtesy, you can ask them to sign up for a shift before opening it up for the group, as it is likely beneficial for them to choose a timeslot towards the end of the round)
-4. Put a note in the #dev channel announcing that the shifts are open for signup. Give the team a week to self-select. This may look something like:
+
+- People who doubled-up the last round (should be left out of this round)
+- People who have very recently started (as a courtesy, you can ask them to sign up for a shift before opening it
+  up for the group, as it is likely beneficial for them to choose a timeslot towards the end of the round)
+
+4. Put a note in the #dev channel announcing that the shifts are open for signup. Give the team a week to
+   self-select. This may look something like:
+
 ```
 :alert: Hello team! It's time to sign up for the next round of on-call, which begins on January 10. Please visit the Notion doc here: <link> which has instructions on how to sign up. Please do so between now and **next Monday, December 17**. After that time I will randomly select shifts. Note relevant tags (notable holidays, the Holiday Volunteer Shifts). Thank you! :tada: :tada:
 ```
+
 5. Remind the team to sign up during open standup, and if necessary on slack.
-6. After announcing that signup is closed, assign the remaining people to shifts randomly. It's helpful to check the OOO calendar to avoid scheduling over someone's vacation.
+6. After announcing that signup is closed, assign the remaining people to shifts randomly. It's helpful to check
+   the OOO calendar to avoid scheduling over someone's vacation.
 7. Create Google calendar events for the shifts:
-  - Create a week-long event on the Engineering On-Call calendar
-  - Invite the on-call person
-  - Name the event "<their name> On-Call"
-  - Check the box so the guest can modify the event
-  - Make sure to say "yes" for sending email invites
-  - I usually create one this way and then duplicate it so all of the settings remain the same
-8. Double-check that the calendar invites look okay, then announce in slack that scheduling has finished. Something like:
+
+- Create a week-long event on the Engineering On-Call calendar
+- Invite the on-call person
+- Name the event "<their name> On-Call"
+- Check the box so the guest can modify the event
+- Make sure to say "yes" for sending email invites
+- I usually create one this way and then duplicate it so all of the settings remain the same
+
+8. Double-check that the calendar invites look okay, then announce in slack that scheduling has finished. Something
+   like:
+
 ```
 Hi team! Just finished creating calendar invites for this round of on-call. If something looks wrong, please let me know! Soon I will be deleting the Notion doc so we can use this as the source of truth. Note that you can still switch shifts if something comes up!
 ```
+
 9. After a couple of days, delete the Notion doc to avoid confusion.
 10. Schedule a reminder to repeat this process for the next round.

--- a/resources/README.md
+++ b/resources/README.md
@@ -9,8 +9,8 @@ Listicles, but on GitHub.
 | [Links to the Art world](/resources/art.md#readme) | How to get up to date on the art world |
 | [Our highlight links about Artsy](/resources/artsy.md#readme) | An overview of links about Artsy and some of our bigger packaged Art content. |
 | [Highlights from our engineering blog](/resources/blog.md#readme) | The best-of from our archives |
+| [Leadership resources](/resources/leadership.md#readme) | The best-of from our [#leadership](https://artsy.slack.com/messages/leadership) 🔒 slack channel |
 | [Highlights from our L&Ls](/resources/lnl.md#readme) | The best-of from our archives |
 | [How to get started on any of our tech stacks](/resources/tech-learning.md#readme) | The getting started guides |
-| [Leadership resources](/resources/leadership.md#readme) | The best-of from our [#leadership](https://artsy.slack.com/messages/leadership) 🔒 slack channel |
 <!-- end_toc -->
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
- Extract "Responding to an Incident" to a separate document
- Move scheduling-related documentation to the scheduling doc
- Clarify on-call staggered rotation process

Paired with @ashfurrow on these updates during today's Writing Office Hours :+1: 