### PR TITLE
Document new framework for system criticality

### DIFF
--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -35,6 +35,7 @@ practice should be incorporated, submit a PR!
 | [How to run a retrospective](/playbooks/retrospectives.md#readme) | The why and how for running a retrospective |
 | [How to create an RFC at Artsy](/playbooks/rfcs.md#readme) | The steps needed to request cultural changes |
 | [How to run a Lunch & Learn](/playbooks/running-lunch-and-learn.md#readme) | How to handle the people process for Lunch & Learns |
+| [System Criticality](/playbooks/system-criticality.md#readme) | A framework for treating systems differently according to how critical they are |
 | [Technology choices](/playbooks/technology-choices.md#readme) | Evaluating and adopting new technology at Artsy |
 <!-- end_toc -->
 <!-- prettier-ignore-end -->

--- a/playbooks/support/README.md
+++ b/playbooks/support/README.md
@@ -3,6 +3,7 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+- [Wait!](#wait)
 - [Process Overview](#process-overview)
 - [On-Call Responsibilities](#on-call-responsibilities)
 - [Responding to an incident](#responding-to-an-incident)
@@ -38,7 +39,9 @@ sprints. See [below](#examples) for some common examples.
 
 ## Wait!
 
-If you are new to on-call or looking for a refresher, we recommend watching the [on-call onboarding session](https://www.dropbox.com/home/Artsy%20Engineering/Onboarding/On-Call) 🔒 we ran on March 8, 2019 which talks through your responsibilities as an on-call engineer.
+If you are new to on-call or looking for a refresher, we recommend watching the
+[on-call onboarding session](https://www.dropbox.com/home/Artsy%20Engineering/Onboarding/On-Call) 🔒 we ran on
+March 8, 2019 which talks through your responsibilities as an on-call engineer.
 
 ## Process Overview
 

--- a/playbooks/system-criticality.md
+++ b/playbooks/system-criticality.md
@@ -1,0 +1,50 @@
+---
+title: System Criticality
+description: A framework for treating systems differently according to how critical they are
+---
+
+We'd like to identify gaps in the health and resilience of our platform as well as prioritize efforts to address
+them, but our platform comprises dozens of systems with very different needs and uses. This framework aims to
+recognize those differences with a shared vocabulary, so we can set expectations for different systems accordingly.
+
+## System Criticality Framework
+
+### Level 3 (_critical_):
+
+Systems that are essential to basic business operations such as registration, authentication, browsing, inquiring,
+bidding, and buying. These systems understandably experience a relatively high throughput, and any disruptions can
+have sizable financial and brand impact.
+
+### Level 2 (_important_):
+
+Systems with limited throughput or public-facing functions. Disruptions may interfere with certain business
+operations or have mild financial or brand impact.
+
+### Level 1 (_supported_):
+
+Internal utilities or systems with only occasional usage. Experimentation should be cheap and easy, so we embrace
+that some tools serve only a few individuals or use cases.
+
+### Level 0 (_unsupported_):
+
+Retired systems, spikes, or time-bound experiments that aren't significantly used. There shouldn't ever be many of
+these systems, and they aren't expected to satisfy the objectives below.
+
+## System expectations (DRAFT)
+
+Each level has corresponding expectations for how the system is built, operated, and maintained:
+
+**These are all TBD pending further discussion.**
+
+|                              | Level 1                                                                      | Level 2                                                                                                    | Level 3                                                                                                                                                                           |
+| ---------------------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Development                  | READMEs contain up-to-date set-up instructions                               | READMEs contain up-to-date set-up instructions                                                             | One-click development environment set-up                                                                                                                                          |
+| Testing and Deployment       | Continuous integration                                                       | Continuous integration<br/>Zero-downtime deployment                                                        | Continuous integration<br/>Zero-downtime deployment<br/> Automated test coverage &gt;=90&percnt;                                                                                  |
+| Availability and Performance |                                                                              | External availability monitoring<br/>&gt;99.9&percnt; uptime                                               | External availability monitoring<br/>&gt;99.99&percnt; uptime<br/>&lt;200ms average response time (APIs)<br/>&lt;1s average response time (interactive sites)                     |
+| Monitoring                   |                                                                              | Application instrumentation (e.g., Datadog)<br/>Error tracking<br/>Latency and error rate threshold alerts | Application instrumentation (e.g., Datadog)<br/>Error tracking<br/>Latency and error rate threshold alerts<br/>Business metric anomaly alerts<br/>Dedicated monitoring dashboards |
+| Support                      | Fixes are prioritized with respective teams' backlogs rather than #incidents | Incident response time &lt;30 min. during waking hours                                                     | Incident response time &lt;5 min.                                                                                                                                                 |
+| Data                         |                                                                              | Weekly backups                                                                                             | Daily backups                                                                                                                                                                     |
+| Security                     |                                                                              | Known vulnerabilities patched within 30 days                                                               | Known vulnerabilities patched within 7 days                                                                                                                                       |
+
+See the [full list of projects](https://github.com/artsy/potential/blob/master/Project-List.md)🔒 for how
+individual systems align with these levels.

--- a/playbooks/system-criticality.md
+++ b/playbooks/system-criticality.md
@@ -28,7 +28,8 @@ that some tools serve only a few individuals or use cases.
 ### Level 0 (_unsupported_):
 
 Retired systems, spikes, or time-bound experiments that aren't significantly used. There shouldn't ever be many of
-these systems, and they aren't expected to satisfy the objectives below.
+these systems, nor should product managers have to consider them. They aren't expected to satisfy the objectives
+below.
 
 ## System expectations (DRAFT)
 


### PR DESCRIPTION
This adds some minimal explanation of how we think about system criticality, based largely on https://github.com/artsy/README/issues/176.

The expectations (also copied from the RFC's examples) are meant as placeholders until we can assign systems and figure out what is practical and possible.