### PR TITLE
Update Running Lunch & Learn doc with new Dropbox folder location

### DIFF
--- a/playbooks/running-lunch-and-learn.md
+++ b/playbooks/running-lunch-and-learn.md
@@ -78,10 +78,10 @@ Right after the talk, ask the speaker for their slides. Check to make sure it's 
 Twitter. Then take the speaker and a few folks out to lunch. Tataki is never a bad choice. Make sure to expense
 this meal.
 
-Later, Zoom.us will email you the video recording. Upload the video and the slides to the Artsy Engineering Dropbox
-folder and post a link to Slack. Send a pull request to the [Lunch and Learn docs][lal] that adds the speaker to
-the list. Make sure to thank the speaker again over email, offer a copy of the video, and reiterate that we owe
-them a talk now.
+Later, Zoom.us will email you the video recording. Upload the video and the slides to the [Everyone at Artsy/Lunch
+& Learn Dropbox folder][dropbox-folder] and post a link to Slack. Send a pull request to the [Lunch and Learn
+docs][lal] that adds the speaker to the list. Make sure to thank the speaker again over email, offer a copy of the
+video, and reiterate that we owe them a talk now.
 
 If the talk was given by an Artsy colleague, ask them if it would be appropriate to upload to YouTube for public
 viewing. Maybe even a quick [blog post][blog].
@@ -90,6 +90,8 @@ If the talk was given by someone outside Artsy, log into the [@ArtsyOpenSource t
 (credentials are in 1Password) to post a tweet thanking them (as long as it's okay with them).
 
 Move the card to the "Done" column. Nice work!
+
+[dropbox-folder]: https://www.dropbox.com/home/Everyone%20at%20Artsy/Lunch%20%26%20Learn
 
 ### Troubleshooting
 

--- a/playbooks/running-lunch-and-learn.md
+++ b/playbooks/running-lunch-and-learn.md
@@ -79,9 +79,15 @@ Twitter. Then take the speaker and a few folks out to lunch. Tataki is never a b
 this meal.
 
 Later, Zoom.us will email you the video recording. Upload the video and the slides to the [Everyone at Artsy/Lunch
-& Learn Dropbox folder][dropbox-folder] and post a link to Slack. Send a pull request to the [Lunch and Learn
-docs][lal] that adds the speaker to the list. Make sure to thank the speaker again over email, offer a copy of the
-video, and reiterate that we owe them a talk now.
+& Learn Dropbox folder][dropbox-folder] and post a link to Slack. Use the following convention to name the
+subfolder:
+
+```
+YYYY-MM-DD <presentation title> with <speaker name>
+```
+
+Send a pull request to the [Lunch and Learn docs][lal] that adds the speaker to the list. Make sure to thank the
+speaker again over email, offer a copy of the video, and reiterate that we owe them a talk now.
 
 If the talk was given by an Artsy colleague, ask them if it would be appropriate to upload to YouTube for public
 viewing. Maybe even a quick [blog post][blog].

--- a/resources/lnl.md
+++ b/resources/lnl.md
@@ -5,25 +5,30 @@ description: The best-of from our archives
 
 ## Artsy's business
 
-- [Auctions](https://www.dropbox.com/home/Artsy%20Engineering/LunchAndLearn/Artsy%20Auctions) 🔒
-- [Consignments](https://www.dropbox.com/home/Artsy%20Engineering/LunchAndLearn/Consignments) 🔒
-- [Gallery Ecosystem](https://www.dropbox.com/home/Artsy%20Engineering/LunchAndLearn/Gallery%20Ecosystem) 🔒
+- [Auctions](https://www.dropbox.com/home/Everyone%20at%20Artsy/Lunch%20&%20Learn/2018-04-05%20-%20Artsy%20Auctions)
+  🔒
+- [Consignments](https://www.dropbox.com/home/Everyone%20at%20Artsy/Lunch%20&%20Learn/2018-05-24%20-%20Consignments)
+  🔒
+- [Gallery Ecosystem](https://www.dropbox.com/home/Everyone%20at%20Artsy/Lunch%20&%20Learn/2018-10-18%20-%20What%20you%20need%20to%20know%20about%20galleries%20on%20Artsy%20with%20Barbara%20and%20Jessica)
+  🔒
 
 ## Folks at Artsy
 
-- [What dB does](https://www.dropbox.com/work/Artsy%20Engineering/LunchAndLearn/What%20Does%20dB%20Do) 🔒
-- [What Devang does](https://www.dropbox.com/work/Artsy%20Engineering/LunchAndLearn/What%20Does%20Devang%20Do) 🔒
-- [What is Product Marketing?](https://www.dropbox.com/work/Artsy%20Engineering/LunchAndLearn/What%20is%20Product%20Marketing)
+- [What dB does](https://www.dropbox.com/home/Everyone%20at%20Artsy/Lunch%20&%20Learn/2018-10-11%20-%20What%20Does%20dB%20Do)
+  🔒
+- [What Devang does](https://www.dropbox.com/home/Everyone%20at%20Artsy/Lunch%20&%20Learn/2018-08-17%20-%20What%20Does%20Devang%20Do)
+  🔒
+- [What is Product Marketing?](https://www.dropbox.com/home/Everyone%20at%20Artsy/Lunch%20&%20Learn/2018-11-08%20-%20What%20is%20Product%20Marketing%20with%20Liz%20Derby)
   🔒
 
 ## Tech
 
-- [GraphQL Best Practices](https://www.dropbox.com/work/Artsy%20Engineering/LunchAndLearn/GraphQL%20best%20practices)
+- [GraphQL Best Practices](https://www.dropbox.com/home/Everyone%20at%20Artsy/Lunch%20&%20Learn/2017-12-21%20-%20GraphQL%20best%20practices)
   🔒
-- [Danger & Peril](https://www.dropbox.com/work/Artsy%20Engineering/LunchAndLearn/Danger%20%26%20Peril?preview=danger+and+peril.mp4)
+- [Danger & Peril](https://www.dropbox.com/home/Everyone%20at%20Artsy/Lunch%20&%20Learn/2018-05-18%20-%20Danger%20&%20Peril)
   🔒
 
 ## DevOps
 
-- [Datadog and Kubernetes](https://www.dropbox.com/home/Artsy%20Engineering/LunchAndLearn/Datadog%20%2B%20Kubernetes)
+- [Datadog and Kubernetes](https://www.dropbox.com/home/Everyone%20at%20Artsy/Lunch%20&%20Learn/2018-06-26%20-%20Datadog%20+%20Kubernetes)
   🔒


### PR DESCRIPTION
Historically, we've archived Lunch & Learn recordings in a Dropbox folder shared only with the Engineering team. While Engineering is responsible for organizing and running Lunch & Learn, all Artsy
employees are welcome to attend and we often host non-technical talks from internal and external speakers.

We've recently created a new Lunch & Learn folder, visible to anyone at Artsy, and copied past Lunch & Learn recordings over.

This commit updates the Running Lunch & Learn playbook to mention and link to this new folder location.

Post merge, I plan to remove the old folder from the Artsy Engineering Dropbox folder and communicate this change with the rest of the Engineering team.