### PR TITLE
Update docs for merging S&T and L&L

### DIFF
--- a/events/README.md
+++ b/events/README.md
@@ -9,7 +9,7 @@ What meetings, and regular events do we have.
 | [Artsy Learns to Code](/events/artsy-learns-to-code.md#readme) | Experimental structure where we teach non-engineering colleagues how to code. |
 | [Demo Days](/events/demo-days.md#readme) | How we showcase shipped projects |
 | [Happy Hours](/events/happy-hour.md#readme) | When all of Artsy comes together with partners, friends, artists and engineers. |
-| [Lunch & Learn](/events/lunch-and-learn.md#readme) | A weekly meetup where we talk about things that inspire us. |
+| [Lunch & Learn](/events/lunch-and-learn.md#readme) | A meetup where we talk about things that inspire us. |
 | [Open Standup](/events/open-standup.md#readme) | How do we do whole-team standup at Artsy? |
 | [Show & Tell](/events/show-and-tell.md#readme) | Internal presentations with no preparation |
 <!-- end_toc -->

--- a/events/lunch-and-learn.md
+++ b/events/lunch-and-learn.md
@@ -1,24 +1,35 @@
 ---
 title: Lunch & Learn
-description: A weekly meetup where we talk about things that inspire us.
+description: A meetup where we talk about things that inspire us.
 ---
 
 # Lunch & Learn
 
-When Artsy was under 50 people, we would hold "Brown Bag" meetings. These were talks on a variety of art+science
-topics. As we out-grew the format, we started doing engineering "Brown Bag" meetings. Occasionally.
+When Artsy was under 50 people, we would hold "Brown Bag" meetings. These were
+talks on a variety of art+science topics. As we out-grew the format, we started
+doing engineering "Brown Bag" meetings. Occasionally.
 
-This worked for a while, but was sporadic and mostly the same speakers. Once we moved to
-[a new stand-up format](https://artsy.github.io/blog/2015/03/23/artsy-technology-stack-2015/) it felt like time to
-re-vamp our brown bags too.
+This worked for a while, but was sporadic and mostly the same speakers. Once we
+moved to [a new stand-up format][standup_post] it felt like time to re-vamp our
+brown bags too.
 
-Our format is pretty simple, every Thursday we have an hour slot at 12:30 (NYC time) on the calendar for someone to
-give a talk or presentation. I think [Alan](https://twitter.com/alanjay1/) described it well on
-[Professional Development at Artsy](https://artsy.github.io/blog/2016/09/22/professional-development-at-artsy-engineering/):
+[standup_post]: https://artsy.github.io/blog/2015/03/23/artsy-technology-stack-2015/
 
-> Every Thursday, we do a Lunch-and-Learn session. Historically, we mostly showed off tech we use internally. But
-> over about a year, most of our tech stack has been presented this way, so we also bring in engineers we know at
+Our format is pretty simple, every other Thursday we have an hour slot at 12:30
+(NYC time) on the calendar for someone to give a talk or presentation. I think
+[Alan][alan] described it well on [Professional Development at
+Artsy][alan_post]:
+
+[alan]: https://twitter.com/alanjay1/
+[alan_post]: https://artsy.github.io/blog/2016/09/22/professional-development-at-artsy-engineering/
+
+> Every Thursday, we do a Lunch-and-Learn session. Historically, we mostly
+> showed off tech we use internally. But over about a year, most of our tech
+> stack has been presented this way, so we also bring in engineers we know at
 > other companies to share what they’re working on.
+
+On the off weeks we have a [Show & Tell](show-and-tell.md) and those weeks where
+we can't find a Lunch & Learn speaker we fall back to doing Show & Tell.
 
 So far, from external contributors we've had:
 
@@ -56,57 +67,67 @@ Here are some examples of internal presentations:
 
 ---
 
-You're probably seeing this as an external developer to Artsy, who has been invited to talk.
+You're probably seeing this as an external developer to Artsy, who has been
+invited to talk.
 
 ## Format
 
-The format is definitely not set in stone, however these are what has worked for us internally and for past
-contributors.
+The format is definitely not set in stone, however these are what has worked for
+us internally and for past contributors.
 
 #### Presentation
 
-Traditional conference/meetup style: You bring slides, we watch. You talk, we listen. You finish, we ask questions.
+Traditional conference/meetup style: You bring slides, we watch. You talk, we
+listen. You finish, we ask questions.
 
-We don't expect conference/meetup-level presentation or practice. A lack of polish is okay. This is a great
-opportunity to present new talks ideas.
+We don't expect conference/meetup-level presentation or practice. A lack of
+polish is okay. This is a great opportunity to present new talks ideas.
 
 #### Company Walkthrough
 
-More informal, you can come with other speakers and talk about the ways in which your company works. Covering your
-tech stack, the decisions behind them. With the presentation mainly being a series of demos, and showing code
-architecture.
+More informal, you can come with other speakers and talk about the ways in which
+your company works. Covering your tech stack, the decisions behind them. With
+the presentation mainly being a series of demos, and showing code architecture.
 
 ## Schedule
 
-- Arrive at Artsy for 12:15pm (we're [401 Broadway, 26th Floor, 10013][401] - Canal St is the closest station)
-- Our receptionist on 26 will get in touch with whoever you've been in contact with, probably [Orta][] or [Ash][]
+- Arrive at Artsy by 12:15pm ([401 Broadway, 26th Floor, 10013][401] - Canal St
+  is the closest station)
+- Our receptionist on 26 will get in touch with whoever you've been in contact
+  with, probably [Orta][] or [Ash][]
 - They will get you set up on our 27th floor Classroom
 - We will set up [a stream](#recording) for global developers and slides
-- We have until 12:30 to get any technical difficulties sorted out ([the docs are here][trouble])
+- We have until 12:30 to get any technical difficulties sorted out ([the docs
+  are here][trouble])
 - You give a presentation (~30 minutes)
 - We ask a bunch of questions (~15 minutes)
 - Whoever helped get you set up takes you out for lunch on us
 
-Artsy Engineering now owes you, and your company
-[a talk back](https://speakerdeck.com/ashfurrow/teaching-and-learning-1). Feel free to arrange that whenever you
-like.
+Artsy Engineering now owes you, and your company [a talk back][ash_talk]. Feel
+free to arrange that whenever you like.
+
+[ash_talk]: https://speakerdeck.com/ashfurrow/teaching-and-learning-1
 
 ## Recording
 
 We ask that we can share a livestream of your talk, because we have a lot of
-[global colleagues](https://www.artsy.net/article/eloy-duran-going-global-5-tips-to-make-remote-work). This
-involves loading a [Zoom.us][] link on your computer and sharing your screen.
+[global colleagues][global_post]. This involves loading a [Zoom.us][] link on
+your computer and sharing your screen.
 
-We also ask that we get a recording of the talk (kept internal within Artsy), for colleagues who couldn't attend or
-want to review your awesome talk later. This is done through Zoom.us automatically, no additional setup is
-required. We'd like to get a copy of your slides, too. Of course, we're happy to send you a copy of the recording.
+[global_post]: https://www.artsy.net/article/eloy-duran-going-global-5-tips-to-make-remote-work
 
-**If you don't want to be recorded, no problem**. We understand that you might talk and show things that are not
-for public consumption. We will not share anything externally without your express permission.
+We also ask that we get a recording of the talk (kept internal within Artsy),
+for colleagues who couldn't attend or want to review your awesome talk later.
+This is done through Zoom.us automatically, no additional setup is required.
+We'd like to get a copy of your slides, too. Of course, we're happy to send you
+a copy of the recording.
+
+**If you don't want to be recorded, no problem**. We understand that you might
+talk and show things that are not for public consumption. We will not share
+anything externally without your express permission.
 
 [orta]: https://github.com/orta
 [ash]: https://github.com/ashfurrow
-[401]:
-  https://www.google.com/maps/place/401+Broadway/@40.718958,-74.0049492,17z/data=!3m1!4b1!4m5!3m4!1s0x89c2598a7196824f:0xddf53435afbdd5b9!8m2!3d40.718954!4d-74.0027552
+[401]: https://www.google.com/maps/place/401+Broadway/@40.718958,-74.0049492,17z/data=!3m1!4b1!4m5!3m4!1s0x89c2598a7196824f:0xddf53435afbdd5b9!8m2!3d40.718954!4d-74.0027552
 [trouble]: https://github.com/artsy/README/blob/master/playbooks/running-lunch-and-learn.md#troubleshooting
 [zoom.us]: https://zoom.us

--- a/events/lunch-and-learn.md
+++ b/events/lunch-and-learn.md
@@ -126,7 +126,7 @@ a copy of the recording.
 talk and show things that are not for public consumption. We will not share
 anything externally without your express permission.
 
-[orta]: https://github.com/orta
+[Roop]: https://github.com/anandaroop
 [ash]: https://github.com/ashfurrow
 [401]: https://www.google.com/maps/place/401+Broadway/@40.718958,-74.0049492,17z/data=!3m1!4b1!4m5!3m4!1s0x89c2598a7196824f:0xddf53435afbdd5b9!8m2!3d40.718954!4d-74.0027552
 [trouble]: https://github.com/artsy/README/blob/master/playbooks/running-lunch-and-learn.md#troubleshooting

--- a/events/show-and-tell.md
+++ b/events/show-and-tell.md
@@ -5,26 +5,23 @@ description: Internal presentations with no preparation
 
 # Show & Tell
 
-Show & Tell is a new, **optional** weekly event we're trying out to get more visibility into what our teammates
-have been working on recently. It is scheduled weekly for a half hour each week (see the shared Engineering Open
-Meetings calendar) and consists of three ten-minute walkthroughs. These walkthroughs are a presentation of
-works-in-progress and _no_ preparation is expected of these presenters. We get people excited about Show & Tell at
-[Monday standups](open_standup.md) and then do an _@here_ an hour beforehand to remind people. We then meet and, in
-an open mic-style, developers step forward to show and tell!
+In order to better know what our teammates are up to, every other week we set
+aside an hour and in an open mic-style setting show each other what we're
+working on. These short talks/demos/code reviews are not meant to be polished
+presentations, but instead impromptu ways we can share lessons learned and cool
+things discovered!
+
+This happens at the same time slot as [Lunch & Learn](lunch-and-learn.md) and we
+alternate between the two events. On Lunch & Learn weeks without a speaker lined
+up, we fall back to doing a bonus Show & Tell.
 
 Previous demos include:
 
 - Cool things with [Cypress](https://www.cypress.io) and [Mapbox](https://www.mapbox.com) by [@anandaroop][roop].
-- Initial work on the new [CocoaPods metadata service](https://github.com/CocoaPods/cocoapods-metadata-service) by
-  [@orta][orta].
+- Initial work on the new [CocoaPods metadata service](https://github.com/CocoaPods/cocoapods-metadata-service) by [@orta][orta].
 - Experimenting with [Rails+React+TypeScript](https://github.com/jonallured/update_queue) with [@jonallured][jon].
-- Preview of
-  [Building Better Software by Building Better Teams](https://appdevcon.nl/session/building-better-software-by-building-better-teams/)
-  by [@ashfurrow][ash].
+- Preview of [Building Better Software by Building Better Teams](https://appdevcon.nl/session/building-better-software-by-building-better-teams/) by [@ashfurrow][ash].
 - Experimenting with [Isomorphic Relay](https://github.com/damassi/isomorphic-relay-app) by [@damassi][chris].
-
-It's still early in the process so we're looking forward to how this event can grow and encourage cross-team
-collaboration and knowledge sharing.
 
 [orta]: https://github.com/orta
 [roop]: https://github.com/anandaroop


### PR DESCRIPTION
After some chatting on Slack:

https://artsy.slack.com/archives/C9ZUJE65V/p1557411649003100

We're looking to use the L&L time slot for both events and alternate weeks.

h/t @alloy for the nudge here!! ❤️ 