### PR TITLE
Add a footer to highlight Artsy Engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,23 @@ If you are on call or asked to fix an immediate issue, check out our doc on
 [how support works](/playbooks/support.md#readme) and reference our
 [support wiki](https://github.com/artsy/potential/wiki) 🔒 for up-to-date playbooks on how to solve issues.
 
-<a rel="license" href="https://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" />
+<a rel="license" href="https://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a>
+
+## About Artsy
+
+[![artsy][footer_logo]][footer_website]
+
+This project is supported by [Artsy][footer_website], a marketplace for buying
+and selling art online. One of our most beloved Engineering principles is being
+[Open Source by Default][footer_open] - learn more about our open source
+projects from [our blog](footer_blog) and following
+[@ArtsyOpenSource](footer_twitter) or check out [our API][footer_api]. If you're
+interested in a career at Artsy, check out our [job postings](footer_jobs)!
+
+[footer_logo]: https://avatars2.githubusercontent.com/u/546231?s=200&v=4
+[footer_website]: https://www.artsy.net/
+[footer_open]: culture/engineering-principles.md#open-source-by-default
+[footer_blog]: https://artsy.github.io/
+[footer_twitter]: https://twitter.com/ArtsyOpenSource
+[footer_api]: https://developers.artsy.net/
+[footer_jobs]: https://www.artsy.net/jobs

--- a/README.md
+++ b/README.md
@@ -65,15 +65,17 @@ If you are on call or asked to fix an immediate issue, check out our doc on
   <img align="left" src="https://avatars2.githubusercontent.com/u/546231?s=200&v=4"/>
 </a>
 
-This project is supported by [Artsy][footer_website], a marketplace for buying
-and selling art online. Because one of our most beloved [Engineering
-Principles][footer_principles] is being [Open Source by Default][footer_open],
-we share a lot of how we work with the open source community. You can learn more
-about our open source projects from [our blog][footer_blog] and following
-[@ArtsyOpenSource][footer_twitter] or check out [our API][footer_api]. If you're
-interested in a career at Artsy, check out our [job postings][footer_jobs]!
+This project is the work of engineers at [Artsy][footer_website], the world's
+leading and largest online art marketplace and platform for discovering art.
+One of our most core [Engineering Principles][footer_principles] is being [Open
+Source by Default][footer_open] which means we strive to share as many details
+of our work as makes sense.
 
-[footer_logo]: https://avatars2.githubusercontent.com/u/546231?s=200&v=4
+You can learn more about this work from [our blog][footer_blog] and by following
+[@ArtsyOpenSource][footer_twitter] or explore our public data by checking out
+[our API][footer_api]. If you're interested in a career at Artsy, read through
+our [job postings][footer_jobs]!
+
 [footer_website]: https://www.artsy.net/
 [footer_principles]: culture/engineering-principles.md
 [footer_open]: culture/engineering-principles.md#open-source-by-default

--- a/README.md
+++ b/README.md
@@ -66,14 +66,16 @@ If you are on call or asked to fix an immediate issue, check out our doc on
 </a>
 
 This project is supported by [Artsy][footer_website], a marketplace for buying
-and selling art online. One of our most beloved Engineering principles is being
-[Open Source by Default][footer_open] - learn more about our open source
-projects from [our blog](footer_blog) and following
+and selling art online. Because one of our most beloved [Engineering
+Principles][footer_principles] is being [Open Source by Default][footer_open],
+we share a lot of how we work with the open source community. You can learn more
+about our open source projects from [our blog](footer_blog) and following
 [@ArtsyOpenSource](footer_twitter) or check out [our API][footer_api]. If you're
 interested in a career at Artsy, check out our [job postings](footer_jobs)!
 
 [footer_logo]: https://avatars2.githubusercontent.com/u/546231?s=200&v=4
 [footer_website]: https://www.artsy.net/
+[footer_principles]: culture/engineering-principles.md
 [footer_open]: culture/engineering-principles.md#open-source-by-default
 [footer_blog]: https://artsy.github.io/
 [footer_twitter]: https://twitter.com/ArtsyOpenSource

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This project is the work of engineers at [Artsy][footer_website], the world's
 leading and largest online art marketplace and platform for discovering art.
 One of our core [Engineering Principles][footer_principles] is being [Open
 Source by Default][footer_open] which means we strive to share as many details
-of our work as makes sense.
+of our work as possible.
 
 You can learn more about this work from [our blog][footer_blog] and by following
 [@ArtsyOpenSource][footer_twitter] or explore our public data by checking out

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ If you are on call or asked to fix an immediate issue, check out our doc on
 
 ## About Artsy
 
-[![artsy][footer_logo]][footer_website]
+<a href="https://www.artsy.net/">
+  <img align="left" src="https://avatars2.githubusercontent.com/u/546231?s=200&v=4"/>
+</a>
 
 This project is supported by [Artsy][footer_website], a marketplace for buying
 and selling art online. One of our most beloved Engineering principles is being

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you are on call or asked to fix an immediate issue, check out our doc on
 
 This project is the work of engineers at [Artsy][footer_website], the world's
 leading and largest online art marketplace and platform for discovering art.
-One of our most core [Engineering Principles][footer_principles] is being [Open
+One of our core [Engineering Principles][footer_principles] is being [Open
 Source by Default][footer_open] which means we strive to share as many details
 of our work as makes sense.
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ This project is supported by [Artsy][footer_website], a marketplace for buying
 and selling art online. Because one of our most beloved [Engineering
 Principles][footer_principles] is being [Open Source by Default][footer_open],
 we share a lot of how we work with the open source community. You can learn more
-about our open source projects from [our blog](footer_blog) and following
-[@ArtsyOpenSource](footer_twitter) or check out [our API][footer_api]. If you're
-interested in a career at Artsy, check out our [job postings](footer_jobs)!
+about our open source projects from [our blog][footer_blog] and following
+[@ArtsyOpenSource][footer_twitter] or check out [our API][footer_api]. If you're
+interested in a career at Artsy, check out our [job postings][footer_jobs]!
 
 [footer_logo]: https://avatars2.githubusercontent.com/u/546231?s=200&v=4
 [footer_website]: https://www.artsy.net/


### PR DESCRIPTION
This PR adds a footer to the README.md file to highlight some aspects of the Artsy Engineering Brand, specifically:

* the blog
* our Twitter account
* Artsy public API
* careers page

Here's how it looks:

<img width="1439" alt="Screen Shot 2019-05-13 at 12 28 16 PM" src="https://user-images.githubusercontent.com/79799/57641442-a3700c00-757a-11e9-8eda-3cfbc4744969.png">

And you can see it live here:

https://github.com/jonallured/README/tree/add-footer

I've seen this done before, here are a few examples:

https://github.com/hashrocket/decent_exposure#about
https://github.com/thoughtbot/factory_bot#about-thoughtbot

I have aspirations of copying this to all our open source repos, but wanted to start here and nail the copy, etc.