### PR TITLE
Update on-call docs based on our transition to OpsGenie

### DIFF
--- a/playbooks/support/README.md
+++ b/playbooks/support/README.md
@@ -82,15 +82,7 @@ See the [responding doc](responding.md).
 
 ## Severity of Incidents
 
-The following definitions are borrowed from
-[Atlassian's playbook](https://www.atlassian.com/software/jira/ops/handbook/responding-to-an-incident):
-
-- **Critical**: A critical incident with very high impact (i.e. customer data loss; customer-facing service like
-  CMS is down)
-- **Major**: A major incident with significant impact (i.e. a large number of images are not showing up; a small
-  number of partners cannot access CMS)
-- **Minor**: A minor incident with low impact (i.e. a single user cannot place a bid in an auction; a page linked
-  from the app is showing a 404)
+See the [responding doc](responding.md#severity-of-incidents) for levels of severity.
 
 ## Best practices
 

--- a/playbooks/support/on-call-slo.md
+++ b/playbooks/support/on-call-slo.md
@@ -21,7 +21,7 @@ on-call response time to incidents.
 
 ### Measuring performance against this SLO
 
-This SLO targets the time between when an incident is first reported in #incidents and a Jira Ops ticket is
+This SLO targets the time between when an incident is first reported in #incidents and an OpsGenie incident is
 created.
 
 ### Live Auctions

--- a/playbooks/support/responding.md
+++ b/playbooks/support/responding.md
@@ -39,8 +39,6 @@ respond to these issues.
 
    Any incident with public impact should be communicated externally via the status page.
 
-   - Use your judgement to select an "Impact" based on severity and duration of the incident. Refer to the
-     [section on Severity of Incidents for guidance](#severity-of-incidents).
    - Communication does not have to be detailed. Not every stage of the incident needs to be communicated on status
      page.
    - Remember that this page is targeted to a public audience (i.e., users and partners) of Artsy products. Some
@@ -128,8 +126,6 @@ Critical incidents have a very high impact:
 - Customer data loss.
 - “All hands on deck.”
 
-The **Critical** level in OpsGenie equates to the **Critical** impact level in statuspage.io.
-
 #### Examples
 
 - Artsy website is down.
@@ -142,8 +138,6 @@ High incidents have a significant impact:
 - A user-facing service is down for a subset of users.
 - Core functionality is impacted for a specific use-case.
 - Need to find the best people to solve as soon as possible.
-
-The **High** level in OpsGenie equates to the **Major** impact level in statuspage.io.
 
 #### Examples
 
@@ -159,8 +153,6 @@ Moderate incidents have a low impact but require some urgency:
 - Core functionality is impacted for a single resource.
 - Should inform the relevant product team about the issue.
 
-The **Moderate** level in OpsGenie equates to the **Minor** impact level in statuspage.io.
-
 #### Examples
 
 - Broken links in Eigen on UNTITLED art fair page
@@ -173,8 +165,6 @@ Low incidents have low impact and low urgency:
 
 - Known issues that are on a product team’s radar.
 - Issues that can be handled in a regular sprint’s work.
-
-Low incidents do not require an update to the Artsy status page.
 
 #### Examples
 

--- a/playbooks/support/responding.md
+++ b/playbooks/support/responding.md
@@ -15,48 +15,67 @@ respond to these issues.
 ## Step 2: Raise
 
 1. When an incident is raised in the channel or identified in another way, the on-call team first **tracks the
-   incident** by creating a ticket in [Jira Ops](https://artsyproduct.atlassian.net/projects/INCIDENT/incidents),
-   based on the information they know at that time. Some workflow steps:
+   incident** by creating an incident in [OpsGenie](https://artsy.app.opsgenie.com/incident/list), based on the
+   information they know at that time. Some workflow steps:
 
-   - In the description on the ticket, link to the slack thread in #incidents or #alerts.
+   - Select Artsy as the Impacted Service.
+   - Enter a quick description of the problem as the Incident message.
+   - Enter a link to the #incidents thread as the Incident description.
+   - Select a Priority level from the list using your gut instinct. Refer to the
+     [section on Severity of Incidents for guidance](#severity-of-incidents).
    - Take your best guess at the other information, it can always be edited later.
 
-2. Using the slack integration on the Jira Ops ticket, create a new slack channel to discuss resolution.
+2. Create a Slack channel for this incident for discussion of the technical resolution.
 
-   _Jira integrations are known to be flakey. If you have trouble getting the integration to work, simply create a channel named `#incident-N` (where `N` corresponds to the Jira Ops ticket) and link to it from the ticket._
+   - Name it #incident-N and invite the other on-call engineer and any other active responders.
+   - Add a link to the OpsGenie incident as the Purpose
 
-3. In the original slack thread in #incidents, put a link to the incident that was created and _direct engineers to
-   the newly created slack channel for discussing its resolution_.
+3. In the original slack thread in #incidents, put a link to the new #incident-N channel and _direct engineers to
+   continue communication in that channel_.
+
+4. Update the [Artsy status page](status.artsy.net) by logging into the
+   [Artsy StatusPage.io](https://manage.statuspage.io/pages/hmhlbjlmdhgh/incidents) account (creds in 1Password).
+
+   Any incident with public impact should be communicated externally via the status page.
+
+   - Use your judgement to select an "Impact" based on severity and duration of the incident. Refer to the
+     [section on Severity of Incidents for guidance](#severity-of-incidents).
+   - Communication does not have to be detailed. Not every stage of the incident needs to be communicated on status
+     page.
+   - Remember that this page is targeted to a public audience (i.e., users and partners) of Artsy products. Some
+     might be subscribed to receive updates on every communication here.
+   - The most important thing is acknowledging the issue, specifying the services affected and communicating key
+     updates and resolutions.
 
 ## Step 3: Assess
 
-1. A member of the on-call team marks the issue as **FIXING**. This person will be automatically assigned to the
-   issue. For the duration of the incident resolution, this person is responsible for _facilitation_. This may
-   involve pulling in other engineers to help solve the problem and delegating tasks like external communication to
-   the other on-call team member.
-2. Determine and update the [severity of the incident](<(#severity-of-incidents)>) by trying to reproduce the
-   problem and following up with stakeholders as-needed. It may be helpful to find answers to the following:
+1. Assign an Incident Commander to the incident. This person is the main point-person for facilitating an incident
+   response. The Incident Commander could be yourself, another on-call engineer, or a Subject Matter Expert. See
+   the [OpsGenie docs](https://docs.opsgenie.com/docs/incident-response-roles) for more details about incident
+   roles.
+
+2. Determine and update the severity of the incident by trying to reproduce the problem and following up with
+   stakeholders as-needed. It may be helpful to find answers to the following:
 
    - How many people (or partners, etc.) does this affect?
    - Have you been able to reproduce?
    - Is this a new problem or something that we are aware of?
 
 3. If the reported incident does not qualify for an immediate response:
-   - Take the time to educate the reporter on the desired process (see the
-  [examples](#examples) below). You may point them to the
-  [Guide to Reporting Bugs](https://www.notion.so/artsy/Guide-to-reporting-bugs-cc25e1ff41194228b476c4963c646817)
-  doc in Notion which describes this in a general way.
+   - Take the time to educate the reporter on the desired process (see the [examples](#examples) below). You may
+     point them to the
+     [Guide to Reporting Bugs](https://www.notion.so/artsy/Guide-to-reporting-bugs-cc25e1ff41194228b476c4963c646817)
+     doc in Notion which describes this in a general way.
    - Direct stakeholders in the slack thread to a product team’s channel to ensure that a Jira Issue is tracked for
      this possible issue
-   - Link the Jira Ops ticket to any relevant bugs that are tracked (and create an additional one if necessary)
-   - Mark the ticket as **CANCELED**
-
+   - Link the OpsGenie incident to any relevant bugs that are tracked (and create an additional one if necessary)
+   - Mark the incident as **CLOSED**
 
 ## Step 4: Address Incident
 
 **Investigate --> Identify --> Escalate --> Fix**
 
-Discuss the incident's resolution in the dedicated slack channel.
+Discuss the incident's resolution in the dedicated Slack channel.
 
 - Fix if possible using [accumulated playbooks (wiki)](https://github.com/artsy/potential/wiki) 🔒.
 - If unable to fix using shared resources, contact the relevant [point-person](#point-people) for help and pair
@@ -66,7 +85,7 @@ Discuss the incident's resolution in the dedicated slack channel.
 - If you make an immediate fix but addressing the root cause requires further work, add the issue to the bug
   backlog so it can be prioritized accordingly.
 
-**Note:** You are not responsible for fixing all of the bugs that you find. Most problems that require a coding
+**Note:** You are **not** responsible for fixing all of the bugs that you find. Most problems that require a coding
 change should be addressed by the relevant team.
 
 ### Communicate
@@ -75,28 +94,93 @@ One of the on-call members handles internal and external communication for the i
 
 - #incidents is for non-on-call people to raise possible incidents or follow up (questions, etc.) about existing
   threads.
-- Resolution happens exclusively in the dedicated slack channel associated with the Jira Ops ticket.
-- Meaningful updates, discoveries, or milestones (e.g. changes in availability or resolution) are added to the Jira
-  Ops ticket by the assignee.
-- Any incident with public impact should be communicated externally via the status page. Communication does not
-  have to be detailed (Not every stage of the incident necessarily need to be communicated on status page). Remember that this page is targeted to a public audience(i.e., users and partners) of Artsy products. Some might be subscribed to receive updates on every communication here. Use your judgement based on severity and duration of the incident. The most important thing is acknowledging the issue, specifying the services affected and communicating key updates and resolutions. Use the status page integration on the Jira Ops ticket for updating Status page.
-
-  _Jira integrations are known to be flakey. If you have trouble getting the integration to work, simply visit [Statuspage](https://statuspage.io), create an incident manually, and link to it from the ticket._
+- Resolution happens exclusively in the dedicated slack channel associated with the OpsGenie incident.
+- Meaningful updates, discoveries, or milestones (e.g. changes in availability or resolution) are added to the
+  OpsGenie incident by its responders.
+- Communicate progress and major milestones publicly through statuspage.io. Updates don't need to be specific, but
+  it is important that we give customers confidence that we are dealing with the incident.
 
 ## Step 5: Resolve
 
 Incidents are resolved when the immediate issue has been mitigated. After that, the team needs to make sure all
-follow-up items are tracked and the Jira Ops ticket clearly reflects this state.
+follow-up items are tracked and the OpsGenie incident clearly reflects this state.
 
 1. Create any necessary follow-up tickets either in the bug backlog or a specific team’s project board. Link these
-   from within the Jira Ops ticket.
-2. Post any final updates to the Jira Ops ticket
+   from within the OpsGenie incident.
+2. Post any final updates to the OpsGenie incident
 
-- Update timestamps
-- Mark the ticket as **RESOLVED**
-- Add any additional labels or metadata that may be relevant later
+   - Add a timeline entry describing why you're resolving the incident
+   - Mark the incident as **RESOLVED**
 
-3. Resolve any outstanding incidents on our status page via the integration on the Jira Ops ticket.
-4. If the incident was Critical, create a post mortem following the guidelines in our
-   [post_mortems repo](https://github.com/artsy/post_mortems).
+3. Resolve any outstanding incidents on our status page via statuspage.io.
+4. If the incident was Critical, create a post mortem in OpsGenie.
 5. Update relevant [playbooks](https://github.com/artsy/potential/wiki) 🔒 with any lessons.
+
+## Severity of Incidents
+
+### P1 - **Critical**
+
+Critical incidents have a very high impact:
+
+- A user-facing service is down for all users.
+- Confidentiality or privacy is breached.
+- Customer data loss.
+- “All hands on deck.”
+
+The **Critical** level in OpsGenie equates to the **Critical** impact level in statuspage.io.
+
+#### Examples
+
+- Artsy website is down.
+- Artsy website is under DDoS attack.
+
+### P2 - **High**
+
+High incidents have a significant impact:
+
+- A user-facing service is down for a subset of users.
+- Core functionality is impacted for a specific use-case.
+- Need to find the best people to solve as soon as possible.
+
+The **High** level in OpsGenie equates to the **Major** impact level in statuspage.io.
+
+#### Examples
+
+- Partners unable to delete artworks in CMS
+- Multiple partners unable to add credit cards
+- Artwork pages showing duplicate information
+
+### P3 - **Moderate**
+
+Moderate incidents have a low impact but require some urgency:
+
+- A user-facing service is down for a single user.
+- Core functionality is impacted for a single resource.
+- Should inform the relevant product team about the issue.
+
+The **Moderate** level in OpsGenie equates to the **Minor** impact level in statuspage.io.
+
+#### Examples
+
+- Broken links in Eigen on UNTITLED art fair page
+- A single partner cannot access CMS
+- User unable to place bid on lot in live sale, needs to be placed in the backend
+
+### P4 - **Low**
+
+Low incidents have low impact and low urgency:
+
+- Known issues that are on a product team’s radar.
+- Issues that can be handled in a regular sprint’s work.
+
+Low incidents do not require an update to the Artsy status page.
+
+#### Examples
+
+- Charge details for a partner need updating.
+- Artwork appearance on the site (“how come it’s not showing up in…”).
+
+### P5 - **Informational**
+
+Informational incidents are used primarily for training. Use this for incidents you create to practice incident
+response.

--- a/playbooks/support/responding.md
+++ b/playbooks/support/responding.md
@@ -173,5 +173,4 @@ Low incidents have low impact and low urgency:
 
 ### P5 - **Informational**
 
-Informational incidents are used primarily for training. Use this for incidents you create to practice incident
-response.
+Informational incidents have no customer impact. They are often created for reporting or training purposes.

--- a/playbooks/support/responding.md
+++ b/playbooks/support/responding.md
@@ -27,7 +27,8 @@ respond to these issues.
 
 2. Create a Slack channel for this incident for discussion of the technical resolution.
 
-   - Name it #incident-N and invite the other on-call engineer and any other active responders.
+   - Name it #incident-N, where N is the incident number from OpsGenie.
+   - Invite the other on-call engineer and any other active responders to the new channel.
    - Add a link to the OpsGenie incident as the Purpose
 
 3. In the original slack thread in #incidents, put a link to the new #incident-N channel and _direct engineers to


### PR DESCRIPTION
I've had to raise a couple incidents this week, and noticed that we didn't have all our README docs updated from our transition to OpsGenie. This PR addresses that.
