### PR TITLE
Basic structure of mobile knowledge base

### DIFF
--- a/practices/front-end-ios.md
+++ b/practices/front-end-ios.md
@@ -59,8 +59,9 @@ Each iOS app at Artsy is deployed according to its own unique needs. See their r
 Initially, Artsy apps were built with Objective-C. Then Swift was announced in 2014, and
 [we tried it](http://artsy.github.io/blog/2017/02/05/Retrospective-Swift-at-Artsy/) but have ultimately
 [settled on React Native](http://artsy.github.io/blog/2018/03/17/two-years-of-react-native/). We will still use
-Objective-C and Swift for the foreseeable future, and native code will likely always make sense for parts of our
-app (notably, [the Augmented Reality feature](http://artsy.github.io/blog/2018/03/18/ar/) and the animation-driven
+Objective-C for the foreseeable future, [Swift is "on hold" at Artsy](https://github.com/artsy/README/pull/217),
+and native code will likely always make sense for parts of our app (notably,
+[the Augmented Reality feature](http://artsy.github.io/blog/2018/03/18/ar/) and the animation-driven
 [Live Auctions Integration](http://artsy.github.io/blog/2016/08/09/the-tech-behind-live-auction-integration/#The.iOS.native.app:.Eigen),
 user interface). New features are being built using React Native; the remaining native parts of our main app are
 [listed here 🔒](https://www.notion.so/artsy/Eigen-migration-to-React-Native-54dda83b023b4cb4965a8defdae9687f)

--- a/resources/mobile/README.md
+++ b/resources/mobile/README.md
@@ -1,0 +1,67 @@
+---
+title: Artsy Mobile Learning Resources
+description: Collections of further reading about iOS and, more specifically, iOS at Artsy.
+---
+
+<!-- prettier-ignore-start -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Getting Started](#getting-started)
+- [An Introduction for React Native Developers](#an-introduction-for-react-native-developers)
+- [How to use Xcode](#how-to-use-xcode)
+- [Fundamentals of Objective-C](#fundamentals-of-objective-c)
+- [How is Artsy's iOS App Architected?](#how-is-artsys-ios-app-architected)
+
+<!-- prettier-ignore-end -->
+
+Don't forget to check out the [Front-End iOS Practice](../practices/front-end-ios.md) for less technical, more
+organizational resources.
+
+## Getting Started
+
+There are three distinct ways of developing iOS software at Artsy:
+
+- Writing React Native components in [Emission](https://github.com/artsy/emission) (setup instructions in Readme)
+- Writing Objective-C and Swift, sometimes using on React Native componts _from_ Emission, in
+  [Eigen](https://github.com/artsy/eigen) (setup instructions in Readme)
+- Developing React Native _and_ Objective-C and Swift using Emission and Eigen linked together, at the same time.
+  [Instructions are in the Eigen docs folder](https://github.com/artsy/eigen/blob/master/docs/using_dev_emission.md)
+
+## An Introduction for React Native Developers
+
+React Native developers are really common at Artsy; any engineer who writes React can write React Native, and
+therefore, can contribute to our iOS software. But for some tasks, React Native alone is not enough – you need some
+native development skills. This section highlights some of the ways that our React Native and native (Objective-C)
+code interoperate.
+
+The best resource to learn about the fundamentals of Artsy's app's interop is
+[this blog post](https://artsy.github.io/blog/2016/08/24/On-Emission/).
+[The Map to Emission](https://github.com/artsy/emission/blob/master/docs/map_to_emission.md) also contains an
+[interop section](https://github.com/artsy/emission/blob/master/docs/map_to_emission.md#eigen-interop) that links
+to further reading.
+
+<!-- TODO: Find some resources on how+why to use Objective-C while developing React Native code. -->
+
+## How to use Xcode
+
+The documentation on how to use Xcode is in the [xcode.md](./xcode.md) doc.
+
+## Fundamentals of Objective-C
+
+<!-- TODO: Find some good foundational Objective-C resources -->
+
+## How is Artsy's iOS App Architected?
+
+Artsy's app is split across [Emission](https://github.com/artsy/emission) (React Native components, some backed by
+Objective-C) and [Eigen](https://github.com/artsy/eigen) (Swift and Objective-C). Eigen depends on Emission. You
+can think of Emission as a component library, and Eigen routes between the components.
+
+Here are some further readings you can do to learn more about why we made these decisions:
+
+- [Our initial blog post on using React Native](https://artsy.github.io/blog/2016/08/15/React-Native-at-Artsy/)
+- [Our 3 year retrospective on using React Native](https://artsy.github.io/blog/2019/03/17/three-years-of-react-native/)
+- [A blog post on how routing works in Eigen](https://artsy.github.io/blog/2015/08/19/Cocoa-Architecture-Switchboard-Pattern/)
+  (predates our use of React Native but the concepts are unchanged)
+- [The Map to Emission](https://github.com/artsy/emission/blob/master/docs/map_to_emission.md) is a list of the
+  different technologies Emission uses, with links to helpful PRs, blog posts, and representative code.

--- a/resources/mobile/README.md
+++ b/resources/mobile/README.md
@@ -23,8 +23,8 @@ organizational resources.
 There are three distinct ways of developing iOS software at Artsy:
 
 - Writing React Native components in [Emission](https://github.com/artsy/emission) (setup instructions in Readme)
-- Writing Objective-C and Swift, sometimes using on React Native componts _from_ Emission, in
-  [Eigen](https://github.com/artsy/eigen) (setup instructions in Readme)
+- Writing Objective-C and Swift in [Eigen](https://github.com/artsy/eigen) (setup instructions in Readme),
+  sometimes importing React Native components _from_ Emission (as Objective-C `ARComponentController` subclasses).
 - Developing React Native _and_ Objective-C and Swift using Emission and Eigen linked together, at the same time.
   [Instructions are in the Eigen docs folder](https://github.com/artsy/eigen/blob/master/docs/using_dev_emission.md)
 

--- a/resources/mobile/summary.json
+++ b/resources/mobile/summary.json
@@ -1,0 +1,4 @@
+{
+  "title": "Artsy Mobile Learning Resources",
+  "description": "Collections of further reading about iOS and, more specifically, iOS at Artsy."
+}

--- a/resources/mobile/xcode.md
+++ b/resources/mobile/xcode.md
@@ -11,7 +11,7 @@ ways:
 
 Either works, but beware! If you have App Store automatic updates enabled, you may come in to work one day and find
 that your IDE has changed (which has implications for Swift language and SDK versions). If you ever need a specific
-version of Xcode, check out Apple's developer portal.
+version of Xcode, check out [Apple's Developer portal 🔐](https://developer.apple.com/download/more/).
 
 Xcode is really different from VSCode. It's Apple's opinion on what a good IDE should be, and sometimes it's
 uncomfortable at first. Some quick differences:

--- a/resources/mobile/xcode.md
+++ b/resources/mobile/xcode.md
@@ -1,0 +1,25 @@
+---
+title: How to Use Xcode
+description: Introduction and further resources to using Xcode
+---
+
+Xcode is Apple's IDE for developing, among many other things, iOS applications. You can install Xcode in one of two
+ways:
+
+- [From the App Store](https://apps.apple.com/us/app/xcode/id497799835?mt=12)
+- [From Apple's Developer portal 🔐](https://developer.apple.com/download/more/)
+
+Either works, but beware! If you have App Store automatic updates enabled, you may come in to work one day and find
+that your IDE has changed (which has implications for Swift language and SDK versions). If you ever need a specific
+version of Xcode, check out Apple's developer portal.
+
+Xcode is really different from VSCode. It's Apple's opinion on what a good IDE should be, and sometimes it's
+uncomfortable at first. Some quick differences:
+
+- Xcode doesn't encourage you to have multiple files open at a time, in tabs.
+- Xcode uses web browser-like history for navigating back-and-forth between files (look at the top-right corner of
+  the file editor for the arrows).
+- Xcode's file browser doesn't represent the file system's directory structure – it is a distinct organization that
+  just _happens_ to match the disk's directory structure most of the time.
+
+<!-- TODO: Find-or-create an Xcode cheat sheet. -->

--- a/resources/tech-learning.md
+++ b/resources/tech-learning.md
@@ -5,10 +5,10 @@ description: The getting started guides
 
 # Tech Learning
 
-We often hear that learning to google (or perhaps [DuckDuckGo](https://duckduckgo.com/)) and use stack overflow are the
-most important core competencies of any programmer, but growth and learning happen best outside the vacuum of the
-internet. This page is a list of the engineering team's favorite resources -tutorials, essays, starting points and
-general thoughts- on a variety of programming topics.
+We often hear that learning to google (or perhaps [DuckDuckGo](https://duckduckgo.com/)) and use stack overflow are
+the most important core competencies of any programmer, but growth and learning happen best outside the vacuum of
+the internet. This page is a list of the engineering team's favorite resources -tutorials, essays, starting points
+and general thoughts- on a variety of programming topics.
 
 This is a living document; if you find something out of date or have an addition please open a pull request.
 
@@ -74,13 +74,14 @@ _See also [Platform Practice Resources](#platform-practice) below_
 
 &nbsp;
 
-### Swift + Objective C
+### iOS, React Native, Swift & Objective C
 
-_See also [Frontend-iOS Practice Resources](#frontend-ios-practice) below_
+iOS, and specifically iOS at Artsy, is such a large topic that we have resources collected under the
+[`mobile` directory](./mobile).
 
 | Name                             | Description                                                                            |
 | -------------------------------- | -------------------------------------------------------------------------------------- |
-| [Cocoa Core Competencies][cocoa] | Deprecated but still useful context around development for iOS, especially Objective C |
+| [Cocoa Core Competencies][cocoa] | Deprecated but still useful context around development for iOS, especially Objective-C |
 | []()                             |                                                                                        |
 
 ## &nbsp;


### PR DESCRIPTION
This PR adds a basic knowledge base for developing iOS software at Artsy, which came out of our Front-End iOS Practice meeting this morning ([notes are here 🔐 ](https://www.notion.so/artsy/July-19-2019-Meeting-Notes-12000fc88fa1480997fb3ac0e7375f04)). The goal is to provide a place where we can accumulate knowledge of how to build iOS software, specifically iOS software at Artsy.

It is a work-in-progress; I've purposefully left some TODO comments to give others a jumping-off point to add their own resources. I couldn't help adding links to docs and blog posts that I think are important, though 😄 The most nebulous section is, and will be, how+why to use Objective-C as a React Native developer. Really exciting times!