### PR TITLE
Add item to start a video conference in On-Call docs

### DIFF
--- a/playbooks/support/responding.md
+++ b/playbooks/support/responding.md
@@ -76,6 +76,9 @@ respond to these issues.
 
 Discuss the incident's resolution in the dedicated Slack channel.
 
+- Start a video conference with Zoom to communicate in real-time with
+  other responders. Credentials to a shared Engineering Zoom Pro account are in
+  1Password.
 - Fix if possible using [accumulated playbooks (wiki)](https://github.com/artsy/potential/wiki) 🔒.
 - If unable to fix using shared resources, contact the relevant [point-person](#point-people) for help and pair
   with them on a fix. Be sure to contribute lessons back to shared documentation. **You are not expected to know


### PR DESCRIPTION
The workplace team recently provisioned a Pro Zoom account for use
during incident response. This Pro account is not limited to a 40 minute
max duration of calls.