### PR TITLE
Cleans up standup instructions

### DIFF
--- a/events/open-standup.md
+++ b/events/open-standup.md
@@ -18,6 +18,8 @@ team up with the engineer that started the preceding Wednesday. **Pick one perso
 The person handling the talking parts does this stuff ten minutes before standup:
 
 - `@here`s the dev channel. Include where the meeting is in the NYC office (usually the Annex).
+- Make sure on-call staff are prepared to give an update about the past week's incidents. (if you were on call,
+  great! If you weren't, remind your partner.)
 - Check the [Lunch&Learn schedule][ll_schedule].
 - The meeting starts with props (as a nod towards [People are Paramount][pplp]) and you should begin with giving
   props of your own.

--- a/events/open-standup.md
+++ b/events/open-standup.md
@@ -6,47 +6,34 @@ description: How do we do whole-team standup at Artsy?
 # Dev Team Standup at Artsy
 
 We've been doing engineering stand-ups for as long as there has been an engineering team. The format has changed
-over time as the size and scope of Artsy has changed. We're now on our fourth iteration of this process.
+over time as the size and scope of Artsy has changed. We're now on our fourth iteration of this process, which you
+can [read more about here][standup_blog].
 
 The current on-call engineers run standup. On-call rotations are staggered so an engineer starting on a Monday will
-team up with the engineer that started the preceding Wednesday. Pick one person to run the talking parts, and one
-person to take notes.
+team up with the engineer that started the preceding Wednesday. **Pick one person to do the talking parts
+(facilitate the meeting) and one person to take notes**.
 
 ### Ten minutes before a standup
 
 The person handling the talking parts does this stuff ten minutes before standup:
 
-- `@here`s the dev channel. Include where the meeting is in the NYC office (usually the Classroom).
-- Remind last week's on-call staff in #dev to prepare their updates about last week's rotation. Something like:
-  > @personA @personB reminder, we're looking for a list of major or notable incidents from last week during
-  > standup.
+- `@here`s the dev channel. Include where the meeting is in the NYC office (usually the Annex).
 - Check the [Lunch&Learn schedule][ll_schedule].
-- Think of who you'd like to give props to.
+- The meeting starts with props (as a nod towards [People are Paramount][pplp]) and you should begin with giving
+  props of your own.
 
 ### During standup
 
-**Important**: Make sure the person taking notes doesn't have their laptop next
-to the Zoom speakerphone.
+**Important**: Make sure the person taking notes doesn't have their laptop next to the Zoom speakerphone.
 
-- Props, as a nod towards [People are Paramount][pplp]
-- Update from the VP of Engineering
-- Update from Product Managers (someone should be present to give one)
-- Update on new hires, people starting this week, newly accepted offers, etc.
-- What the practices (Front-End, Front-End iOS, and Platform) are currently thinking about
-- Update from last week's on-call support team, including follow-up work items
-- Potential cross-team dependencies and requests for pairing
-- Open RFCs (see Peril's Monday morning post in the #dev Slack channel or [here on
-  GitHub][open-rfcs-github])
-- Running peer learning groups (the leads/participates will present this)
-- Milestones spot to talk about things people are proud of (new repos, blog
-  posts, updated functionality, etc.)
-- We then either announce [the Lunch & Learn][ll], or try find one for the week
-- Anyone is free to give closing announcements, or props!
+The person who is facilitating the meeting should use the template below as an agenda.
 
-[open-rfcs-github]: https://github.com/issues?utf8=%E2%9C%93&q=org%3Aartsy+label%3ARFC+state%3Aopen
+## After standup
 
 These notes are then copied into a [Notion][] document, and the link passed into #dev on Slack after standup.
 Everyone else leaves links to things they have commented on during the meeting, if they don't, we chase them up.
+
+Finally, **review this document** for ways to improve the instructions for next week's meeting.
 
 ## Our Markdown Template
 
@@ -75,8 +62,8 @@ _Practice Updates_
 
 _On-call Support Updates_
 
-- This week, @personC and @personD will be on-call for support.
-- ## Last week, we saw the following notable incidents (please include follow-up details)
+- This week, @personC and @personD will be on-call for support until Wednesday, when @personE rotates on.
+- Last week, we saw the following notable incidents (please include follow-up details)
 
 _Cross-dependencies / Requests for Pairing_
 
@@ -90,7 +77,8 @@ _Running peer learning groups_
 
 -
 
-_New Milestones / Repos / Blog Posts / New features or updated functionality released: prompt Auction, Gallery, Platform, Grow, Purchase teams_
+_New Milestones / Repos / Blog Posts / New features or updated functionality released: prompt Auction, Gallery,
+Platform, Grow, Purchase teams_
 
 -
 
@@ -100,13 +88,11 @@ _Lunch & Learn_ || _Show & Tell_ (if you don't know, ask in #lunch_and_learn or 
 
 _Closing Announcements_
 
-- The last two support engineers should stick around to chat with us, the new support engineers after this meeting.
 -
 ```
-
-Once you're done, follow the instructions [in Notion][notion] on how to add it to our archives.
 
 [pplp]: https://github.com/artsy/README/blob/master/culture/what-is-artsy.md#people-are-paramount
 [ll]: https://github.com/artsy/README/blob/master/events/lunch-and-learn.md
 [ll_schedule]: https://github.com/artsy/README/projects/1
 [notion]: https://www.notion.so/artsy/Standup-Notes-28a5dfe4864645788de1ef936f39687c
+[standup_blog]: https://artsy.github.io/blog/2018/05/07/fully-automated-standups/


### PR DESCRIPTION
This PR updates our standup instructions. Here's the summary:

- **Remove the agenda**. We should use the template as the agenda, to avoid having to keep two lists in sync.
- **Adds follow-up note** to review these docs and update them as needed.
- **Links to a blog post** explaining the philosophy of our standup.
- **Removes support handoff** since this is happening in a staggered way and is covered by our support docs. In practice, we were never doing this anyway, so we should remove it from the agenda.
- **Removes reminder of incidents** in pre-meeting instructions. The people running the meeting are on-call and probably don't need to remind themselves; we could update the Peril message to remind them if we need to.
- A few other cleanups, like moving to the Annex and telling the facilitator to explicitly start the meeting with their own props (which I forgot to do this morning).

All these changes are up for discussion, just let me know 👍 