### PR TITLE
Update sprint rotation recommendations

### DIFF
--- a/onboarding/engineering-introduction.md
+++ b/onboarding/engineering-introduction.md
@@ -20,10 +20,8 @@ Artsy has an open vacation policy. This doesn't mean "don't take vacation." _Ple
 take off for bank holidays.
 
 Join the
-[Design/Product OOO](https://calendar.google.com/calendar/embed?src=artsymail.com_gl81jptn59gjfv1kg0fer1i4jo%40group.calendar.google.com&ctz=America%2FNew_York)
-calendar and use that to set when you know you'll be out of the office (you don't generally need to post remote
-work here unless it's out of the ordinary and would benefit from wider communication i.e. you'll be working for a
-month from somewhere else).
+[Design/Product OOO calendar](https://calendar.google.com/calendar/embed?src=artsymail.com_gl81jptn59gjfv1kg0fer1i4jo%40group.calendar.google.com&ctz=America%2FNew_York)
+and use that to set when you know you'll be out of the office or unavailable.
 
 ### Chat
 
@@ -36,8 +34,7 @@ See the [events list](/events) for descriptions of our recurring, engineering-wi
 [Engineering - Open Meetings calendar](https://calendar.google.com/calendar/r?cid=YXJ0c3ltYWlsLmNvbV9nODFpbzRhOThkZHZuMWloMWEzbG0yb2NkNEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t)
 to see when they are scheduled and feel free to add yourself to any (or just show up).
 
-We have an engineering team-wide standup on _Mondays at 11:30 a.m. Eastern_ (virtual:
-[https://zoom.us/my/artsyclassroom](https://zoom.us/my/artsyclassroom)) where we:
+We have an engineering team-wide standup on _Mondays at 11:30 a.m. Eastern_ where we:
 
 - Share any team updates
 - Mention significant project milestones or new repositories
@@ -50,12 +47,13 @@ The standup is fully documented [here](/events/open-standup.md).
 ### Getting Help
 
 - **Slack:** If you know what team could potentially help you, browse the channels in Slack to find the most
-  relevant place to ask your question. If you aren't sure, [#dev](https://artsy.slack.com/messages/dev) 🔒 is a
-  good place to start.
+  relevant place to ask your question. If you aren't sure, all engineers are in
+  [#dev](https://artsy.slack.com/messages/dev) 🔒 and [#dev-help](https://artsy.slack.com/messages/dev-help)🔒 is a
+  good place for general questions.
 - **Ask Your Neighbor:** Everyone is friendly. Don't hesitate to reach out to the people around you for even the
   most basic of questions.
-- **Check Atlas:** Turns out a lot of common questions are available in [atlas.artsy.net](http://atlas.artsy.net)
-  🔒.
+- **Check Atlas:** Many company-wide resources and questions are addressed in
+  [atlas.artsy.net](http://atlas.artsy.net) 🔒.
 
 ## Who we are
 
@@ -84,12 +82,14 @@ Artsy stores source code on [GitHub](https://github.com/artsy). Make sure you ha
 Artsy organization. If you can't visit [this page](https://github.com/artsy/gravity) 🔒, then you don’t have the
 right access. Your mentor can get you sorted out.
 
-Our projects use physics terms as code names, starting with [Gravity](https://github.com/artsy/gravity) 🔒
-(inspired by [Zachary Coffin's "Temple of Gravity"](http://www.zacharycoffin.com/work/temple-of-gravity)).
+Our projects
+[use physics terms as code names](https://artsy.github.io/blog/2019/05/10/why-projects-need-codenames/), starting
+with [Gravity](https://github.com/artsy/gravity) 🔒 (inspired by
+[Zachary Coffin's "Temple of Gravity"](http://www.zacharycoffin.com/work/temple-of-gravity)).
 
 See the [engineering projects map](https://www.notion.so/artsy/17c4b550458a4cb8bcbf1b68060d63e6) 🔒 for a
-comprehensive list of our (many) repos and who owns them. It can be a bit overwhelming, so here are some important
-ones:
+comprehensive list of our (many) repos and associated teams. It can be a bit overwhelming, so here are some
+important ones:
 
 - [Gravity](https://github.com/artsy/gravity) 🔒: Artsy's main API
 - [Force](https://github.com/artsy/force): Artsy web site ([www.artsy.net](https://www.artsy.net))
@@ -110,13 +110,10 @@ which evolved from [our stack in 2015](https://artsy.github.io/blog/2015/03/23/a
 evolved from [our tech stack at launch in 2012](https://artsy.github.io/blog/2012/10/10/artsy-technology-stack/),
 which evolved from a Rails monolith.
 
-### Artsy APIs
+### Artsy APIs and concepts
 
-See [apis](https://github.com/artsy/potential/blob/master/apis/README.md) 🔒 in Potential.
-
-### Artsy Data
-
-See [data](https://github.com/artsy/potential/blob/master/data/README.md) 🔒.
+See [apis](https://github.com/artsy/potential/blob/master/apis/README.md) 🔒 and
+[domain models](https://github.com/artsy/potential/blob/master/platform/DomainModels.md) in Potential.
 
 ## How We Work
 
@@ -130,6 +127,9 @@ dependencies for local development (homebrew, Ruby, etc.).
 
 Projects can provide their own setup scripts that build on this common foundation. See
 [Gravity's script/setup](https://github.com/artsy/gravity/blob/master/script/setup) 🔒 as an example.
+
+Most projects use the [hokusai](https://github.com/artsy/hokusai) wrapper for testing, configuration, and
+deployment to kubernetes. The `hokusai dev ...` commands simplify local development using Docker.
 
 ### Text Editor
 
@@ -151,7 +151,7 @@ can find a
 ### Contributing Code
 
 As all of our code is housed on GitHub, we make contributions through
-[pull requests](https://artsy.github.io/blog/2012/01/29/how-art-dot-sy-uses-github-to-build-art-dot-sy/).
+[pull requests](/playbooks/engineer-workflow.md#pull-requests).
 
 Read more in [the engineer workflow playbook](/playbooks/engineer-workflow.md#readme) or see this
 [step-by-step guide](https://github.com/artsy/potential/blob/master/github/workflow.md) 🔒. If you're unfamiliar

--- a/onboarding/engineering-introduction.md
+++ b/onboarding/engineering-introduction.md
@@ -113,7 +113,7 @@ which evolved from a Rails monolith.
 ### Artsy APIs and concepts
 
 See [apis](https://github.com/artsy/potential/blob/master/apis/README.md) 🔒 and
-[domain models](https://github.com/artsy/potential/blob/master/platform/DomainModels.md) in Potential.
+[domain models](https://github.com/artsy/potential/blob/master/platform/DomainModels.md) 🔒 in Potential.
 
 ## How We Work
 

--- a/onboarding/managers.md
+++ b/onboarding/managers.md
@@ -27,7 +27,7 @@ description: Things for managers to remember during the early days of onboarding
 - [ ] Introduce new hire to their mentor
 - [ ] When they are set up with Slack add them to the `@developers`
       [user group](https://artsy.slack.com/admin/user_groups) 🔒, which should automatically invite them to
-      developer related channels, and invite them to channels relavent to the individual
+      developer related channels, and invite them to channels relevant to the individual
 
 ### Week 1
 

--- a/onboarding/managers.md
+++ b/onboarding/managers.md
@@ -9,17 +9,25 @@ description: Things for managers to remember during the early days of onboarding
 
 - [ ] Choose a peer mentor for the new hire
 - [ ] Choose a spirit guide for the new hire (consult with People Ops)
-- [ ] Create [an onboarding github issue](https://github.com/artsy/README/issues/new?template=engineering-onboarding.md) in this repo based on the onboarding template. Also invite the team to say hi, as this is a place that the new hire should always be able to find easily in the future.
-- [ ] Set first-week schedule and let the new hire know their first day schedule on their private email account, as there will be a period where their machine is still being setup and they won’t yet have access to their calendar.
+- [ ] Create
+      [an onboarding github issue](https://github.com/artsy/potential/issues/new?template=engineering-onboarding.md)🔒
+      based on the onboarding template. Also invite the team to say hi, as this is a place that the new hire should
+      always be able to find easily in the future.
+- [ ] Set first-week schedule and let the new hire know their first day schedule on their private email account, as
+      there will be a period where their machine is still being setup and they won’t yet have access to their
+      calendar.
 - [ ] Invite new hire to all engineering-wide meetings
 - [ ] Determine [sprint rotation plan](/onboarding/sprint-rotation.md)
 
 ### Day 1
 
 - [ ] Organize lunch outing (probably to Tataki!)
-- [ ] Give an overview of what the onboarding will look like. This is a good time to walk through the onboarding template.
+- [ ] Give an overview of what the onboarding will look like. This is a good time to walk through the onboarding
+      template.
 - [ ] Introduce new hire to their mentor
-- [ ] When they are set up with Slack add them to the `@developers` [user group](https://artsy.slack.com/admin/user_groups) 🔒, which should automatically invite them to developer related channels, and invite them to channels relavent to the individual
+- [ ] When they are set up with Slack add them to the `@developers`
+      [user group](https://artsy.slack.com/admin/user_groups) 🔒, which should automatically invite them to
+      developer related channels, and invite them to channels relavent to the individual
 
 ### Week 1
 
@@ -27,11 +35,15 @@ description: Things for managers to remember during the early days of onboarding
 
 ### And onward!
 
-- [ ] When the new hire is assigned to an initial product team, work with the PM/tech lead of that team to make sure they are set up and invited to all relevant meetings.
-- [ ] Remind tech leads/PMs that are part of the sprint rotation to prepare resources and invite new hire to meetings
+- [ ] When the new hire is assigned to an initial product team, work with the PM/tech lead of that team to make
+      sure they are set up and invited to all relevant meetings.
+- [ ] Remind tech leads/PMs that are part of the sprint rotation to prepare resources and invite new hire to
+      meetings
 
 ## Onboarding New Managers
 
 - [ ] Invite to meetings relevant to managers.
 - [ ] Invite to engineering onboarding calendar.
-- [ ] Remind tech-leads/PMs that the new manager’s main objective is to get to meet and work with everybody. As such they should be given diverse tasks and e.g. coupled with various engineers for pairing sessions, as well as leaving them with time to have 1:1s with all the engineers (including tech-lead), PM, and designer.
+- [ ] Remind tech-leads/PMs that the new manager’s main objective is to get to meet and work with everybody. As
+      such they should be given diverse tasks and e.g. coupled with various engineers for pairing sessions, as well
+      as leaving them with time to have 1:1s with all the engineers (including tech-lead), PM, and designer.

--- a/onboarding/sprint-rotation.md
+++ b/onboarding/sprint-rotation.md
@@ -5,49 +5,39 @@ description: What is the sprint rotation and how does it work?
 
 ## Sprint Rotation
 
-After an engineer has gone through basic onboarding (setting up systems, etc.) which will last about a week, they may spend a few sprints switching between different teams.
+Once an engineer has gone through general onboarding and done some basic set-up, they'll spend the following few
+sprints rotating through a variety of engineering teams.
 
-### Why a sprint rotation?
+### Why rotate?
 
-When engineers begin at Artsy, we want them to develop an understanding of our systems and business at a pace that fits their current experience. There's a lot of information to absorb and when engineers start on a product team with immediate sprint goals, there's often not the time or space to learn about the many facets of Artsy.
+We want engineers to be familiar with the full breadth of products, systems, and people at Artsy, but at a
+comfortable pace. Rather than immediately joining a team for the long-term and focusing on that team's priorities,
+rotations allow engineers to tour the teams, get to know other engineers, and touch a variety of layers and
+systems. These rotations may influence the choice of team an engineer joins, or may just provide valuable context
+to their future work.
 
-The sprint rotation is an attempt to mitigate that worry, and also make onboarding/mentorship a shared responsibility. If an engineer switches teams at the start of a new quarter, they should be able to consume the same documentation or expertise that a team has developed for the sprint rotation.
+### How do sprint rotations work?
 
-#### Goals
-- Get up-to-speed on Artsy's systems by being part of different product teams.
-- Learn about different sides of Artsy's business in a first-hand way.
-- Get to know our engineering team and how different engineers and teams work.
+Managers will arrange for new engineers to join a sequence of 3 or more teams for 1 sprint each. Emphasis should be
+on encountering a variety of teams and technology rather than having impact in a familiar space. Following these
+rotations, the engineer will join a team on a more stable basis.
 
-### How does the sprint rotation work?
+#### Managers' responsibilities
 
-A new engineer's manager will work with tech leads to determine the proper length of the sprint rotation and which teams will be involved. This process can be used for the sole purpose of onboarding, and/or to help choose which team the new engineer will start on full-time.
+- Taking into account other rotating engineers and individual teams' schedules, managers add each rotation to the
+  [engineering onboarding calendar](https://calendar.google.com/calendar/b/1?cid=YXJ0c3ltYWlsLmNvbV9jc2RocTFnNHNyMmhhY2Nvc3RmMTA1bTEwc0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t)🔒.
+- For each rotation, managers should nominate a pairing partner from the team. This other engineer can help the new
+  engineer get set up, include them in their own sprint work, and be a primary point of contact for context about
+  tickets and projects.
+- Collaborate with each team's technical lead to ensure a healthy backlog of
+  [`good-first-issue`s](https://artsyproduct.atlassian.net/issues/?jql=labels%20%3D%20good-first-issue).
 
-Following the sprint rotation, the new engineer will join a team full-time.
+#### New engineers' responsibilities
 
-#### Before the rotation starts
-- Manager schedules the duration and content of the sprint rotation, being cognizant of factors like:
-  - Other team members also going through sprint rotation
-  - Schedule of tech leads/PMs
-  - Specific areas of interest for new engineer
-- Manager makes sure the tech lead/PM are aware (well in advance) of the upcoming rotation.
-
-#### Before the sprint starts
-_Manager responsibilities:_
-- The week before the new sprint starts, make sure the new engineer is set up to meet with the tech lead of the team for the upcoming sprint (and if they are available, the PM).
-
-_New engineer responsibilities:_
-- Engineer attends sprint planning for the team they'll be rotating onto.
-- Pending time, the engineer can get their dev environment set up with any additional systems.
-- Pending time, the engineer can browse the team's documentation and current sprint projects.
-
-_Tech lead/PM responsibilities:_
-- Meet with the new engineer to discuss the focus for the upcoming sprint and help them get acquainted or onboarded with any team processes or systems.
-- Add the engineer to all team meetings _just for that sprint_. This includes standups, knowledge shares, retros, and the sprint planning for the assigned sprint (which will likely occur the week before).
-- Make sure the backlog has a healthy number of `good-first-issue` tickets that can be picked up during the sprint.
-- Let the team know that the sprint rotation will be happening so they are prepared to pair on tasks and feel comfortable explicitly scheduling that if necessary.
-- Invite the new engineer to necessary slack user groups and/or google groups for the team.
-
-#### During the sprint
-- Engineer will pair on critical sprint tasks with members of the team.
-- Engineer will work on non-blocking small tasks (i.e. those [tagged with](https://artsyproduct.atlassian.net/issues/?jql=labels%20%3D%20good-first-issue) `good-first-issue`), pairing with their mentor or members of the team if necessary.
-
+- Engineers should join distribution lists and slack channels, and attend team events such as sprint planning.
+- When possible, join pairing partners or other team members on their sprint work.
+- When a pair isn't available, it can be useful to work independently on:
+  - setting up development environments for the team's major systems
+  - reviewing the [team's documentation](https://www.notion.so/artsy/Product-470238180cf94c87906ef1d3ee259e05)🔒
+  - [`good-first-issue` tickets](https://artsyproduct.atlassian.net/issues/?jql=labels%20%3D%20good-first-issue)
+    within the team's backlog

--- a/onboarding/sprint-rotation.md
+++ b/onboarding/sprint-rotation.md
@@ -44,3 +44,5 @@ rotations, the engineer will join a team on a more stable basis.
   - reviewing the [team's documentation](https://www.notion.so/artsy/Product-470238180cf94c87906ef1d3ee259e05)🔒
   - [`good-first-issue` tickets](https://artsyproduct.atlassian.net/issues/?jql=labels%20%3D%20good-first-issue)
     within the team's backlog
+- Schedule a convenient time (30 minutes should be sufficient) with the product manager to be introduced to the
+  team's goals and metrics.

--- a/onboarding/sprint-rotation.md
+++ b/onboarding/sprint-rotation.md
@@ -24,18 +24,21 @@ rotations, the engineer will join a team on a more stable basis.
 
 #### Managers' responsibilities
 
-- Taking into account other rotating engineers and individual teams' schedules, managers add each rotation to the
-  [engineering onboarding calendar](https://calendar.google.com/calendar/b/1?cid=YXJ0c3ltYWlsLmNvbV9jc2RocTFnNHNyMmhhY2Nvc3RmMTA1bTEwc0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t)🔒.
-- For each rotation, managers should nominate a pairing partner from the team. This other engineer can help the new
-  engineer get set up, include them in their own sprint work, and be a primary point of contact for context about
-  tickets and projects.
+- Taking into account other rotating engineers and individual teams' schedules, managers decide an appropriate
+  sequence of rotations and add each to the
+  [engineering onboarding calendar](https://calendar.google.com/calendar/b/1?cid=YXJ0c3ltYWlsLmNvbV9jc2RocTFnNHNyMmhhY2Nvc3RmMTA1bTEwc0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t)🔒,
+  inviting the engineer as well as the chosen team's technical lead and product manager.
+- For each rotation, managers should nominate a "buddy" from the team. This other engineer can help the new
+  engineer get set up, pair on their own sprint work, and be a primary point of contact for context about tickets
+  and projects. A new hire's [mentor](/onboarding/mentors.md) is a great choice for initial rotation "buddy."
 - Collaborate with each team's technical lead to ensure a healthy backlog of
   [`good-first-issue`s](https://artsyproduct.atlassian.net/issues/?jql=labels%20%3D%20good-first-issue).
 
 #### New engineers' responsibilities
 
-- Engineers should join distribution lists and slack channels, and attend team events such as sprint planning.
-- When possible, join pairing partners or other team members on their sprint work.
+- Engineers should join team slack channels, distribution lists, and events. (Confirm that joining the team's
+  google group adds team events such as sprint planning to your calendar.)
+- When possible, pair with your buddy or other team members on their sprint work.
 - When a pair isn't available, it can be useful to work independently on:
   - setting up development environments for the team's major systems
   - reviewing the [team's documentation](https://www.notion.so/artsy/Product-470238180cf94c87906ef1d3ee259e05)🔒


### PR DESCRIPTION
* Fix a few links
* Add new links to #dev-help, blog post on code names, domain models, hokusai, and the onboarding calendar.
* Recommend at least 3 rotations of 1 sprint each.
* Recommend nominating a "pairing partner" in each team. This ends up happening anyway or just falling to the technical lead. Better [I think] to encourage pairing and ensure a buddy is available in each rotation.

I struggled to locate a good link that would list teams (including future ones, once they exist) and ideally link to each of those teams' docs, but [this](https://www.notion.so/artsy/Product-470238180cf94c87906ef1d3ee259e05) was the best I could find (and it was pretty out-of-date). Am I missing a better alternative? Or is this another thing that has to wait for the one true documentation repository 🙏 👼 🙏 ?

*As always, some of these changes are prettier's rather than my own.
