### PR TITLE
[RFC] mention tech plans at stand-up and recommend review discussions

### DIFF
--- a/events/open-standup.md
+++ b/events/open-standup.md
@@ -69,7 +69,7 @@ _Cross-dependencies / Requests for Pairing_
 
 -
 
-_Current team-wide RFCs_ (see #dev for list 9am EST on Mondays)
+_Open RFCs (see #dev for list 9am EST on Mondays) or technical plans under consideration_
 
 -
 

--- a/playbooks/technology-choices.md
+++ b/playbooks/technology-choices.md
@@ -48,11 +48,15 @@ a [technical plan document](https://github.com/artsy/README/issues/245)
 ([examples](https://www.notion.so/artsy/Technical-Plans-f94b206fcec54cee8b4d864e67d5b70f)🔒). This document is a
 good place to state the problem, surface questions, and list possible approaches. Feedback should be invited from
 relevant experts within the team _and beyond_, because these circumstances are rarely unique, and the choices tend
-to outlast specific projects or even teams.
+to outlast specific projects or even teams. [Weekly engineering stand-up](/events/open-standup.md) is a good
+opportunity to ask for the wider engineering team's input.
 
-Sometimes consensus can be achieved with the document alone, but often a [technology review]() discussion helps
-resolve open questions. Ultimately, a team's engineers should recommend a path forward. If there still isn't clear
-agreement, you may want to revisit the problem and rationale (or just ask engineering leadership to weigh in).
+Once initial feedback and updates are reflected on the technical plan document, a face-to-face _technical review_
+discussion is an efficient way to resolve open issues and confirm next steps. This discussion can be scheduled for
+standing practice meetings, team knowledge-shares, or ad hoc if necessary. In the review, the relevant teams'
+engineers are responsible for recommending a path forward. (If there isn't clear agreement, you may want to revisit
+the problem and rationale.) The teams' technical leads and someone from engineering leadership (Dir/VP) should be
+stakeholders on the plan and invited to the review discussion as well.
 
 When a plan depends on technology that isn't in the "adopt" category, it's worth special care to:
 


### PR DESCRIPTION
Several of us were recently discussing how to ensure technical plans surface the most relevant feedback. It's not always obvious who may have worked on a problem in the past (including in past teams/roles) or have other important insight or context.

**Proposal 1:** We already mention RFCs at big stand-up. I think it's appropriate to also mention any active technical plans. This ensures engineers outside of a given team or slack channel hear about significant changes and have the opportunity to offer feedback or attend the review discussion. If there end up being too many (or too minor) plans mentioned at this opportunity, we can revisit this.

**Proposal 2:** I updated the doc's language to recommend a review discussion (even a brief one) more strongly. I _don't_ want to create additional meeting burden, so I suggested using existing forums for this.

**Proposal 3:** Stakeholders are clearly called out in our technical plan templates, but responsibilities and authority are less clear. I updated the doc's language to suggest that the proposing teams' engineers are responsible for _recommending_ one approach, and at least someone from "engineering leadership (Dir/VP)" is included as a stakeholder. @SamRozen and I have cross-team visibility and responsibility in our roles so can at least take the burden of reviewing any plan docs, if not attending the discussions.

