### PR TITLE
Adds description for Redis+Sidekiq docs, applies Prettier

### DIFF
--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -33,6 +33,8 @@ practice should be incorporated, submit a PR!
 | [How to give a good Informational](/playbooks/informationals.md#readme) | What are the steps needed to give someone a great experience. |
 | [Jira](/playbooks/jira.md#readme) | Working with Jira boards and tickets |
 | [Kubernetes](/playbooks/kubernetes.md#readme) | Deploying containerized applications at Artsy |
+| [Migrating Redis](/playbooks/migrating-redis.md#readme) | How to migrate data between Redis instances. |
+| [Migrating Sidekiq](/playbooks/migrating-sidekiq.md#readme) | How to migrate Sidekiq to a new Redis instance |
 | [Open-sourcing a project](/playbooks/open-sourcing.md#readme) | How to take a private repo and make it open-source |
 | [How to run a retrospective](/playbooks/retrospectives.md#readme) | The why and how for running a retrospective |
 | [How to create an RFC at Artsy](/playbooks/rfcs.md#readme) | The steps needed to request cultural changes |

--- a/playbooks/migrating-redis.md
+++ b/playbooks/migrating-redis.md
@@ -1,16 +1,29 @@
+---
+title: Migrating Redis
+description: How to migrate data between Redis instances.
+---
+
 # Migrating Redis
 
-We publish a [Docker image](https://hub.docker.com/r/artsy/redis-migrate) `artsy/redis-migrate` that can be used to migrate all keys in a redis database (on the same or different instance) to another - source code can be found in our [docker-images repo](https://github.com/artsy/docker-images/tree/master/redis-migrate)
+We publish a [Docker image](https://hub.docker.com/r/artsy/redis-migrate) `artsy/redis-migrate` that can be used to
+migrate all keys in a redis database (on the same or different instance) to another - source code can be found in
+our [docker-images repo](https://github.com/artsy/docker-images/tree/master/redis-migrate)
 
-Unfortunately AWS' managed Redis deployments on Elasticache do not allow us to use Redis' built-in [MIGRATE](https://redis.io/commands/migrate) command, which would have made this a lot easier.  Essentially this script attempts to implement this command, but without deleting the key in the source database.
+Unfortunately AWS' managed Redis deployments on Elasticache do not allow us to use Redis' built-in
+[MIGRATE](https://redis.io/commands/migrate) command, which would have made this a lot easier. Essentially this
+script attempts to implement this command, but without deleting the key in the source database.
 
-> The command internally uses DUMP to generate the serialized version of the key value, and RESTORE in order to synthesize the key in the target instance. The source instance acts as a client for the target instance. If the target instance returns OK to the RESTORE command, the source instance deletes the key using DEL.
+> The command internally uses DUMP to generate the serialized version of the key value, and RESTORE in order to
+> synthesize the key in the target instance. The source instance acts as a client for the target instance. If the
+> target instance returns OK to the RESTORE command, the source instance deletes the key using DEL.
 
 ## Migrate an application
 
-Note: this migration process does not ensure data consistency if your app is activaly using Redis.  If you want to ensure data consistency, make sure to shut down your app or disable Redis writes in between steps 1 & 2, and re-enable it after step 3.
+Note: this migration process does not ensure data consistency if your app is activaly using Redis. If you want to
+ensure data consistency, make sure to shut down your app or disable Redis writes in between steps 1 & 2, and
+re-enable it after step 3.
 
-1) Check the old Redis URL
+1. Check the old Redis URL
 
 ```
 hokusai [staging|production] get REDIS_URL
@@ -18,27 +31,36 @@ hokusai [staging|production] get REDIS_URL
 
 This will be supplied to the migration container via `$SOURCE_REDIS_URL`
 
-2) Migrate all keys from the old Redis database to the new - plug in the old and new Redis URLs to `$SOURCE_REDIS_URL` and `$DESTINATION_REDIS_URL`
+2. Migrate all keys from the old Redis database to the new - plug in the old and new Redis URLs to
+   `$SOURCE_REDIS_URL` and `$DESTINATION_REDIS_URL`
 
+4a) Run `docker pull artsy/redis-migrate:latest` to pull the `artsy/redis-migrate:latest` image to your local
+Docker image cache, busting the cache if you happen to have an older version. Note: this step will become obsolte
+[in Docker version 19.09](https://github.com/moby/moby/issues/13331#issuecomment-493531462) with the
+[addition](https://github.com/docker/cli/pull/1498) of the `--pull` flag to `docker run`
 
-4a) Run `docker pull artsy/redis-migrate:latest` to pull the `artsy/redis-migrate:latest` image to your local Docker image cache, busting the cache if you happen to have an older version.  Note:  this step will become obsolte [in Docker version 19.09](https://github.com/moby/moby/issues/13331#issuecomment-493531462) with the [addition](https://github.com/docker/cli/pull/1498) of the `--pull` flag to `docker run`
-
-4b) Connect to the staging or production VPN and [ensure your local Docker is configured to use the VPN interface](https://www.notion.so/artsy/VPN-Configuration-60798c292185407687356997bf251d8c).
+4b) Connect to the staging or production VPN and
+[ensure your local Docker is configured to use the VPN interface](https://www.notion.so/artsy/VPN-Configuration-60798c292185407687356997bf251d8c).
 
 4c) Run `docker run -ti artsy/redis-migrate:latest $SOURCE_REDIS_URL $DESTINATION_REDIS_URL`
 
-See https://github.com/artsy/docker-images/tree/master/redis-migrate for further options / enviornment variables to enable debug logging, perform a dry run, or clean up the source redis database's keys.
+See https://github.com/artsy/docker-images/tree/master/redis-migrate for further options / enviornment variables to
+enable debug logging, perform a dry run, or clean up the source redis database's keys.
 
-3) Update your app to use the new Redis Url
+3. Update your app to use the new Redis Url
 
 ```
 hokusai [staging|production] env set "REDIS_URL=$DESTINATION_REDIS_URL"
 ```
 
-4) Refresh the application
+4. Refresh the application
 
 ```
 hokusai [staging|production] refresh
 ```
 
-5) Update your app's Redis database assignments in our [staging](https://github.com/artsy/infrastructure/blob/master/terraform/staging/redis-database-assignments.tf) and [production](https://github.com/artsy/infrastructure/blob/master/terraform/production/redis-database-assignments.tf) Terrform config so we can track and reference it in our "shared-redis-db-assignments" Kubernetes ConfigMap
+5. Update your app's Redis database assignments in our
+   [staging](https://github.com/artsy/infrastructure/blob/master/terraform/staging/redis-database-assignments.tf)
+   and
+   [production](https://github.com/artsy/infrastructure/blob/master/terraform/production/redis-database-assignments.tf)
+   Terrform config so we can track and reference it in our "shared-redis-db-assignments" Kubernetes ConfigMap

--- a/playbooks/migrating-sidekiq.md
+++ b/playbooks/migrating-sidekiq.md
@@ -1,10 +1,17 @@
+---
+title: Migrating Sidekiq
+description: How to migrate Sidekiq to a new Redis instance
+---
+
 # Migrating Sidekiq
 
-We publish a [Docker image](https://hub.docker.com/r/artsy/sidekiq-migrate) `artsy/sidekiq-migrate` that can be used to migrate Sidekiq jobs from one Redis database (on the same or different instance) - source code can be found in our [docker-images repo](https://github.com/artsy/docker-images/tree/master/sidekiq-migrate)
+We publish a [Docker image](https://hub.docker.com/r/artsy/sidekiq-migrate) `artsy/sidekiq-migrate` that can be
+used to migrate Sidekiq jobs from one Redis database (on the same or different instance) - source code can be found
+in our [docker-images repo](https://github.com/artsy/docker-images/tree/master/sidekiq-migrate)
 
 ## Migrate an application
 
-1) Check the old Redis URL
+1. Check the old Redis URL
 
 ```
 hokusai [staging|production] get REDIS_URL
@@ -12,13 +19,13 @@ hokusai [staging|production] get REDIS_URL
 
 This will be supplied to the migration container via `$SIDEKIQ_OLD_REDIS_URL`
 
-2) Update to the new Redis Url
+2. Update to the new Redis Url
 
 ```
 hokusai [staging|production] env set "REDIS_URL=$SIDEKIQ_NEW_REDIS_URL"
 ```
 
-3) Refresh the application
+3. Refresh the application
 
 ```
 hokusai [staging|production] refresh
@@ -26,16 +33,27 @@ hokusai [staging|production] refresh
 
 At this point, you should see a squeaky clean Sidekiq dashboard at your application's Sidekiq admin URL.
 
-4) Migrate Sidekiq jobs and stats from the old Redis instance - plug in the old and new Redis URLs to `$SIDEKIQ_OLD_REDIS_URL` and `$SIDEKIQ_NEW_REDIS_URL`
+4. Migrate Sidekiq jobs and stats from the old Redis instance - plug in the old and new Redis URLs to
+   `$SIDEKIQ_OLD_REDIS_URL` and `$SIDEKIQ_NEW_REDIS_URL`
 
-4a) Run `docker pull artsy/sidekiq-migrate:latest` to pull the `artsy/sidekiq-migrate:latest` image to your local Docker image cache, busting the cache if you happen to have an older version.  Note:  this step will become obsolte [in Docker version 19.09](https://github.com/moby/moby/issues/13331#issuecomment-493531462) with the [addition](https://github.com/docker/cli/pull/1498) of the `--pull` flag to `docker run`
+4a) Run `docker pull artsy/sidekiq-migrate:latest` to pull the `artsy/sidekiq-migrate:latest` image to your local
+Docker image cache, busting the cache if you happen to have an older version. Note: this step will become obsolte
+[in Docker version 19.09](https://github.com/moby/moby/issues/13331#issuecomment-493531462) with the
+[addition](https://github.com/docker/cli/pull/1498) of the `--pull` flag to `docker run`
 
-4b) Connect to the staging or production VPN and [ensure your local Docker is configured to use the VPN interface](https://www.notion.so/artsy/VPN-Configuration-60798c292185407687356997bf251d8c).
+4b) Connect to the staging or production VPN and
+[ensure your local Docker is configured to use the VPN interface](https://www.notion.so/artsy/VPN-Configuration-60798c292185407687356997bf251d8c).
 
-4c) Run `docker run -ti --env "SIDEKIQ_OLD_REDIS_URL=$SIDEKIQ_OLD_REDIS_URL" --env "SIDEKIQ_NEW_REDIS_URL=$SIDEKIQ_NEW_REDIS_URL" artsy/sidekiq-migrate:latest`
+4c) Run
+`docker run -ti --env "SIDEKIQ_OLD_REDIS_URL=$SIDEKIQ_OLD_REDIS_URL" --env "SIDEKIQ_NEW_REDIS_URL=$SIDEKIQ_NEW_REDIS_URL" artsy/sidekiq-migrate:latest`
 
-See https://github.com/artsy/docker-images/tree/master/sidekiq-migrate for further options / enviornment variables to enable debug logging, perform a dry run, or clean up the source redis database's Sidekiq-specific keys.
+See https://github.com/artsy/docker-images/tree/master/sidekiq-migrate for further options / enviornment variables
+to enable debug logging, perform a dry run, or clean up the source redis database's Sidekiq-specific keys.
 
 Refresh the Sidekiq dashboard at and confirm everything is migrated.
 
-5) Update your app's Redis database assignments in our [staging](https://github.com/artsy/infrastructure/blob/master/terraform/staging/redis-database-assignments.tf) and [production](https://github.com/artsy/infrastructure/blob/master/terraform/production/redis-database-assignments.tf) Terrform config so we can track and reference it in our "shared-redis-db-assignments" Kubernetes ConfigMap
+5. Update your app's Redis database assignments in our
+   [staging](https://github.com/artsy/infrastructure/blob/master/terraform/staging/redis-database-assignments.tf)
+   and
+   [production](https://github.com/artsy/infrastructure/blob/master/terraform/production/redis-database-assignments.tf)
+   Terrform config so we can track and reference it in our "shared-redis-db-assignments" Kubernetes ConfigMap


### PR DESCRIPTION
To keep the README repo consistent, we run a few scripts using a git commit hook (installed through [Husky](https://github.com/typicode/husky) upon `yarn install`). These scripts generate a table of contents based on YAML frontmatter, as well as running docs through Prettier. My guess is these docs were created+edited without having run `yarn install` in the repo.

This is only an issue because, while working on #294, I had the following added to my commit:

```diff
diff --git a/playbooks/README.md b/playbooks/README.md
index 79c43c2..30f6225 100644
--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -33,6 +33,8 @@ practice should be incorporated, submit a PR!
 | [How to give a good Informational](/playbooks/informationals.md#readme) | What are the steps needed to give someone a great experience. |
 | [Jira](/playbooks/jira.md#readme) | Working with Jira boards and tickets |
 | [Kubernetes](/playbooks/kubernetes.md#readme) | Deploying containerized applications at Artsy |
+| [[TODO] add title via yml front-matter to playbooks/migrating-redis.md](/playbooks/migrating-redis.md#readme) | [TODO] add description via yml front-matter to playbooks/migrating-redis.md |
+| [[TODO] add title via yml front-matter to playbooks/migrating-sidekiq.md](/playbooks/migrating-sidekiq.md#readme) | [TODO] add description via yml front-matter to playbooks/migrating-sidekiq.md |
 | [Open-sourcing a project](/playbooks/open-sourcing.md#readme) | How to take a private repo and make it open-source |
 | [How to run a retrospective](/playbooks/retrospectives.md#readme) | The why and how for running a retrospective |
 | [How to create an RFC at Artsy](/playbooks/rfcs.md#readme) | The steps needed to request cultural changes |
```

So I thought I'd take care of that in its own PR. Let me know where I can clarify.