### PR TITLE
add playbooks/migrating-postgres-with-rubyrep.md

### DIFF
--- a/playbooks/migrating-postgres-with-rubyrep.md
+++ b/playbooks/migrating-postgres-with-rubyrep.md
@@ -62,7 +62,7 @@ Apply with `hokusai [staging|production] create --filename ./hokusai/export-old-
 
 Delete with `hokusai [staging|production] delete --filename ./hokusai/export-old-production.yml`
 
-To restore to the new datanase, create the folling Yaml file as `./hokusai/import-to-new-production.yml`
+To restore to the new database, create the folling Yaml file as `./hokusai/import-to-new-production.yml`
 
 ```
 ---

--- a/playbooks/migrating-postgres-with-rubyrep.md
+++ b/playbooks/migrating-postgres-with-rubyrep.md
@@ -1,0 +1,227 @@
+---
+title: Migrating Postgres with Rubyrep
+description: How to migrate a Postgres to a new instance using Rubyrep
+---
+
+# Migrating Postgres with Rubyrep
+
+To set up database replication via [rubyrep](rubyrep.org), do the following:
+
+1) Create the new Postgres database and user
+
+2) Start a shell in the application with the new database connection and load the app schema with:
+```
+hokusai [staging|production] run --env "DATABASE_URL=postgres://{new database credentials}" "bundle exec rake db:schema:load"
+```
+
+3) Check the database schemas.
+  3a) If you want to download a dump of the current db to a local postgres, you can check schemas by running `rake db:schema:dump` locally, and checking in the diff in `db/schema.rb`.  You can also inspect the `schema_migrations` tables across the databases and compare to migrations.
+  3b) Log into the new database and note all foreign key constraints.  You can get foreign key constraints for each table with `\d+ table`.  Save the constraints to later re-enable.
+
+4) Disable all foreign key constraints, for example for tables `foo` and `bar` you would run:
+```
+ALTER TABLE foo DROP CONSTRAINT fk_rails_fbc9d01ca0;
+ALTER TABLE bar DROP CONSTRAINT fk_rails_80eb82ccbf;
+```
+
+5) Create the file `hokusai/rubyrep-config.yml` (Credentials here are redacted but they should be supplied to Kubernetes and this file should not be checked in!) The "left" configuration refers to the source database and the "right" refers to the target database.  Note that for rails apps we can ignore both `ar_internal_metadata` and `schema_migrations` tables.
+
+```
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: myapp
+  name: rubyrep-myapp
+  namespace: default
+data:
+  default.conf: |
+    RR::Initializer::run do |config|
+      config.left = {
+        :adapter  => 'postgresql',
+        :database => 'REDACTED',
+        :username => 'REDACTED',
+        :password => 'REDACTED',
+        :host     => 'OLD_DATABASE',
+        :sslmode  => 'require',
+        :logger   => STDOUT
+      }
+
+      config.right = {
+        :adapter  => 'postgresql',
+        :database => 'REDACTED',
+        :username => 'REDACTED',
+        :password => 'REDACTED',
+        :host     => 'NEW_DATABASE',
+        :sslmode  => 'require',
+        :logger   => STDOUT
+      }
+
+      config.include_tables /./
+      config.exclude_tables 'ar_internal_metadata'
+      config.exclude_tables 'schema_migrations'
+
+      config.options[:adjust_sequences] = false
+
+      config.options[:logged_replication_events] = [:all_changes, :all_conflicts]
+
+    end
+```
+
+Create the configmap with:
+```
+$ hokusai [staging|production] create --filename ./hokusai/rubyrep-config.yml
+```
+
+6) Create the file `./hokusai/rubyrep.yml`.  When the deployment is created, rubyrep will perform an initial sync.
+
+```
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: myapp-rubyrep
+  namespace: default
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: myapp
+        component: rubyrep
+        layer: data
+      name: myapp-rubyrep
+    spec:
+      containers:
+        - name: rubyrep-myapp
+          image: artsy/rubyrep
+          args: ["/rubyrep-2.0.1/rubyrep", "--verbose", "replicate", "-c", "/mnt/default.conf"]
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+          volumeMounts:
+            - name: rubyrep-myapp
+              mountPath: /mnt/default.conf
+              subPath: default.conf
+      volumes:
+        - name: rubyrep-myapp
+          configMap:
+            name: rubyrep-myapp
+```
+
+Create the deployment with:
+```
+$ hokusai [staging|production] create --filename ./hokusai/rubyrep.yml
+```
+
+7) When the database is synced and replication is active, we are ready to make a cutover. To avoid race conditions regarding auto-incrementing primary keys, we will have to accept a brief window of downtime while performing a cutover to the new database.
+
+  7a) Scale all deployments down to 0 replicas.  You may need to temporarily delete horizontal pod autoscalers if configured.
+  ```
+  kubectl --context [staging|production] delete hpa myapp-web
+  kubectl --context [staging|production] scale deployment/myapp-web --replicas 0
+  ```
+
+  7b) Confirm that replication is complete.  You can tail logs from the `myapp-rubyrep` pod or run a rubyrep scan:
+  ```
+  kubectl --context [staging|production] run rubyrep-$(whoami) --restart=Never --rm -i --tty --overrides '
+  {
+    "apiVersion": "v1",
+    "kind": "Pod",
+    "spec": {
+      "containers": [
+        {
+          "name": "rubyrep",
+          "image": "artsy/rubyrep",
+          "stdin": true,
+          "stdinOnce": true,
+          "tty": true,
+          "volumeMounts": [{
+            "mountPath": "/mnt/default.conf",
+            "subPath": "default.conf",
+            "name": "rubyrep-myapp"
+          }]
+        }
+      ],
+      "volumes": [{
+        "name": "rubyrep-myapp",
+        "configMap": {
+          "name": "rubyrep-myapp"
+        }
+      }]
+    }
+  }' --image artsy/rubyrep -- /rubyrep-2.0.1/rubyrep --verbose scan -c /mnt/default.conf
+  ```
+
+  7c) Stop replication by deleting the replication deployment
+  ```
+  $ hokusai [staging|production] delete --filename ./hokusai/rubyrep.yml
+  ```
+
+  7d) IMPORTANT! Re-enable foreign key constraints
+  ```
+  ALTER TABLE foo ADD CONSTRAINT fk_rails_fbc9d01ca0 FOREIGN KEY (bar_id) REFERENCES bar(id);
+  ALTER TABLE bar ADD CONSTRAINT fk_rails_80eb82ccbf FOREIGN KEY (foo_id) REFERENCES foo(id) ON DELETE CASCADE;
+  ```
+
+  7e) IMPORTANT! Reset table id sequences as Rubyrep does not propogate them
+  ```
+  SELECT setval('foo_id_seq', COALESCE((SELECT MAX(id) FROM foo), 1), false);
+  SELECT setval('bar_id_seq', COALESCE((SELECT MAX(id) FROM bar), 1), false);
+  ```
+
+  7c) Update the DATABASE_URL environment variable
+  ```
+  hokusai [staging|production] env set "DATABASE_URL={new database url}"
+  ```
+
+  7d) Scale deployments back up to their original values
+  ```
+  hokusai [staging|production] update
+  ```
+
+
+8) Finally, clean up rubyrep's tables and triggers...
+```
+$ kubectl config use-context [staging|production]
+$ kubectl run rubyrep-$(whoami) --restart=Never --rm -i --tty --overrides '
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "spec": {
+    "containers": [
+      {
+        "name": "rubyrep",
+        "image": "artsy/rubyrep",
+        "stdin": true,
+        "stdinOnce": true,
+        "tty": true,
+        "volumeMounts": [{
+          "mountPath": "/mnt/default.conf",
+          "subPath": "default.conf",
+          "name": "rubyrep-myapp"
+        }]
+      }
+    ],
+    "volumes": [{
+      "name": "rubyrep-myapp",
+      "configMap": {
+        "name": "rubyrep-myapp"
+      }
+    }]
+  }
+}' --image artsy/rubyrep -- /rubyrep-2.0.1/rubyrep --verbose uninstall -c /mnt/default.conf
+
+```
+
+...and delete the rubyrep configmap
+```
+$ hokusai [staging|production] delete --filename ./hokusai/rubyrep-config.yml
+```

--- a/playbooks/migrating-postgres-with-rubyrep.md
+++ b/playbooks/migrating-postgres-with-rubyrep.md
@@ -99,7 +99,6 @@ spec:
         - production
         - "--clean --no-owner --schema=public -j 5 -v"
         env:
-        env:
         - name: APP_NAME
           value: myapp
         - name: DATABASE_URL

--- a/playbooks/migrating-postgres-with-rubyrep.md
+++ b/playbooks/migrating-postgres-with-rubyrep.md
@@ -16,7 +16,26 @@ hokusai [staging|production] run --env "DATABASE_URL=postgres://{new database cr
 
 3) Check the database schemas.
   3a) If you want to download a dump of the current db to a local postgres, you can check schemas by running `rake db:schema:dump` locally, and checking in the diff in `db/schema.rb`.  You can also inspect the `schema_migrations` tables across the databases and compare to migrations.
-  3b) Log into the new database and note all foreign key constraints.  You can get foreign key constraints for each table with `\d+ table`.  Save the constraints to later re-enable.
+  3b) Log into the new database and note all foreign key constraints.  You can get foreign key constraints for each table with `\d+ table` or to see forign key constraints for all tables in the `public` schema, run:
+  ```
+  SELECT conrelid::regclass AS table_from
+       , conname
+       , pg_get_constraintdef(oid)
+  FROM   pg_constraint
+  WHERE  contype IN ('f')
+  AND    connamespace = 'public'::regnamespace  -- your schema here
+  ORDER  BY conrelid::regclass::text, contype DESC;
+  ```
+
+  Example output:
+  ```
+       table_from     |       conname       |                    pg_get_constraintdef
+--------------------+---------------------+-------------------------------------------------------------
+ foo                  | fk_rails_fbc9d01ca0 | FOREIGN KEY (bar_id) REFERENCES bar(id)
+ bar                  | fk_rails_80eb82ccbf | FOREIGN KEY (foo_id) REFERENCES foo(id) ON DELETE CASCADE
+```
+
+Save the constraints to later re-enable.
 
 4) Disable all foreign key constraints, for example for tables `foo` and `bar` you would run:
 ```
@@ -45,7 +64,7 @@ data:
         :password => 'REDACTED',
         :host     => 'OLD_DATABASE',
         :sslmode  => 'require',
-        :logger   => STDOUT
+        # :logger   => STDOUT
       }
 
       config.right = {
@@ -55,7 +74,7 @@ data:
         :password => 'REDACTED',
         :host     => 'NEW_DATABASE',
         :sslmode  => 'require',
-        :logger   => STDOUT
+        # :logger   => STDOUT
       }
 
       config.include_tables /./
@@ -64,7 +83,7 @@ data:
 
       config.options[:adjust_sequences] = false
 
-      config.options[:logged_replication_events] = [:all_changes, :all_conflicts]
+      # config.options[:logged_replication_events] = [:all_changes, :all_conflicts]
 
     end
 ```
@@ -121,15 +140,13 @@ Create the deployment with:
 $ hokusai [staging|production] create --filename ./hokusai/rubyrep.yml
 ```
 
-7) When the database is synced and replication is active, we are ready to make a cutover. To avoid race conditions regarding auto-incrementing primary keys, we will have to accept a brief window of downtime while performing a cutover to the new database.
+7) When the database is synced and replication is active, we are ready to make a cutover. To avoid race conditions regarding auto-incrementing primary keys, first we need to reset the table id sequences, leaving an offset for writes to the new database and replication from the old.  Check database / application write throughput to determine a reasonable value (i.e. writes/minute * 5) to leave room for the deployment rollout.  For, example, given an offset of `100`, run:
+```
+SELECT setval('foo_id_seq', COALESCE((SELECT MAX(id)+100 FROM foo), 1), false);
+SELECT setval('bar_id_seq', COALESCE((SELECT MAX(id)+100 FROM bar), 1), false);
+```
 
-  7a) Scale all deployments down to 0 replicas.  You may need to temporarily delete horizontal pod autoscalers if configured.
-  ```
-  kubectl --context [staging|production] delete hpa myapp-web
-  kubectl --context [staging|production] scale deployment/myapp-web --replicas 0
-  ```
-
-  7b) Confirm that replication is complete.  You can tail logs from the `myapp-rubyrep` pod or run a rubyrep scan:
+  7a) Confirm that replication is complete.  If you want to see verbose logging from the Rubyrep deployment, uncomment the logger sections in the above configuration, and delete the existing rubyrep pod to roll it out.  You can tail then logs from the `myapp-rubyrep` pod and/or run a rubyrep scan:
   ```
   kubectl --context [staging|production] run rubyrep-$(whoami) --restart=Never --rm -i --tty --overrides '
   {
@@ -160,35 +177,29 @@ $ hokusai [staging|production] create --filename ./hokusai/rubyrep.yml
   }' --image artsy/rubyrep -- /rubyrep-2.0.1/rubyrep --verbose scan -c /mnt/default.conf
   ```
 
-  7c) Stop replication by deleting the replication deployment
+  7b) Update the application's DATABASE_URL environment variable
+  ```
+  hokusai [staging|production] env set "DATABASE_URL={new database url}"
+  ```
+
+  7c) Refresh the application
+  ```
+  hokusai [staging|production] refresh
+  ```
+
+  7d) Once the rollout is complete and all writes are going to the new database / replication is complete, stop replication by deleting the rubyrep deployment
   ```
   $ hokusai [staging|production] delete --filename ./hokusai/rubyrep.yml
   ```
 
-  7d) IMPORTANT! Re-enable foreign key constraints
+  7e) IMPORTANT! Remember to re-enable foreign key constraints
   ```
   ALTER TABLE foo ADD CONSTRAINT fk_rails_fbc9d01ca0 FOREIGN KEY (bar_id) REFERENCES bar(id);
   ALTER TABLE bar ADD CONSTRAINT fk_rails_80eb82ccbf FOREIGN KEY (foo_id) REFERENCES foo(id) ON DELETE CASCADE;
   ```
 
-  7e) IMPORTANT! Reset table id sequences as Rubyrep does not propogate them
-  ```
-  SELECT setval('foo_id_seq', COALESCE((SELECT MAX(id) FROM foo), 1), false);
-  SELECT setval('bar_id_seq', COALESCE((SELECT MAX(id) FROM bar), 1), false);
-  ```
 
-  7c) Update the DATABASE_URL environment variable
-  ```
-  hokusai [staging|production] env set "DATABASE_URL={new database url}"
-  ```
-
-  7d) Scale deployments back up to their original values
-  ```
-  hokusai [staging|production] update
-  ```
-
-
-8) Finally, clean up rubyrep's tables and triggers...
+8) Finally, clean up Rubyrep's tables and triggers...
 ```
 $ kubectl config use-context [staging|production]
 $ kubectl run rubyrep-$(whoami) --restart=Never --rm -i --tty --overrides '

--- a/playbooks/migrating-postgres-with-rubyrep.md
+++ b/playbooks/migrating-postgres-with-rubyrep.md
@@ -45,7 +45,7 @@ spec:
         - name: APP_NAME
           value: { myapp }
         - name: DATABASE_URL
-          value: { old-database-url }
+          value: { old database url }
         - name: AWS_ACCESS_KEY_ID
           value: { app aws access key id }
         - name: AWS_SECRET_ACCESS_KEY
@@ -97,7 +97,7 @@ spec:
         - name: APP_NAME
           value: { myapp }
         - name: DATABASE_URL
-          value: { new-database-url }
+          value: { new database url }
         - name: AWS_ACCESS_KEY_ID
           value: { app aws access key id }
         - name: AWS_SECRET_ACCESS_KEY
@@ -160,22 +160,20 @@ data:
     RR::Initializer::run do |config|
       config.left = {
         :adapter  => 'postgresql',
-        :database => 'REDACTED',
-        :username => 'REDACTED',
-        :password => 'REDACTED',
-        :host     => 'OLD_DATABASE',
-        :sslmode  => 'require',
-        :logger   => STDOUT
+        :database => { old database name },
+        :username => { old database username },
+        :password => { old database password },
+        :host     => { old database host },
+        :sslmode  => 'require'
       }
 
       config.right = {
         :adapter  => 'postgresql',
-        :database => 'REDACTED',
-        :username => 'REDACTED',
-        :password => 'REDACTED',
-        :host     => 'NEW_DATABASE',
-        :sslmode  => 'require',
-        :logger   => STDOUT
+        :database => { new database name },
+        :username => { new database username },
+        :password => { new database password },
+        :host     => { new database host },
+        :sslmode  => 'require'
       }
 
       config.include_tables /./
@@ -191,11 +189,12 @@ data:
       config.options[:logged_replication_events] = :all_conflicts
 
     end
+
 ```
 
 Create the configmap with:
 ```
-$ hokusai production create --filename ./hokusai/rubyrep-config.yml
+$ hokusai [staging|production] create --filename ./hokusai/rubyrep-config.yml
 ```
 
 6) Create the file `./hokusai/rubyrep.yml`.  When the deployment is created, rubyrep will perform an initial sync.
@@ -242,7 +241,7 @@ spec:
 
 Create the deployment with:
 ```
-$ hokusai production create --filename ./hokusai/rubyrep.yml
+$ hokusai [staging|production] create --filename ./hokusai/rubyrep.yml
 ```
 
 7) When the database is synced and replication is active, we are ready to make a cutover.
@@ -291,12 +290,12 @@ $ hokusai production create --filename ./hokusai/rubyrep.yml
 
   7c) Update the application's DATABASE_URL environment variable
   ```
-  hokusai production env set "DATABASE_URL={new database url}"
+  hokusai [staging|production] env set "DATABASE_URL={new database url}"
   ```
 
   7d) Refresh the application
   ```
-  hokusai production refresh
+  hokusai [staging|production] refresh
   ```
 
   7e) Once the rollout is complete and all writes are going to the new database, Rubyrep's replication will work in reverse, propogating all changes from the new database back to the old.
@@ -315,7 +314,7 @@ $ hokusai production create --filename ./hokusai/rubyrep.yml
 
   7g) Stop replication by deleting the Rubyrep deployment
   ```
-  $ hokusai production delete --filename ./hokusai/rubyrep.yml
+  $ hokusai [staging|production] delete --filename ./hokusai/rubyrep.yml
   ```
 
 
@@ -354,5 +353,5 @@ $ kubectl --context [staging|production] run rubyrep-$(whoami) --restart=Never -
 
 ...and delete the rubyrep configmap
 ```
-$ hokusai production delete --filename ./hokusai/rubyrep-config.yml
+$ hokusai [staging|production] delete --filename ./hokusai/rubyrep-config.yml
 ```

--- a/playbooks/migrating-postgres-with-rubyrep.md
+++ b/playbooks/migrating-postgres-with-rubyrep.md
@@ -83,7 +83,11 @@ data:
 
       config.options[:adjust_sequences] = false
 
-      # config.options[:logged_replication_events] = [:all_changes, :all_conflicts]
+      config.options[:sync_conflict_handling] = :left_wins
+      config.options[:logged_sync_events] = :all_conflicts
+
+      config.options[:replication_conflict_handling] = :left_wins
+      config.options[:logged_replication_events] = :all_conflicts
 
     end
 ```

--- a/playbooks/migrating-postgres-with-rubyrep.md
+++ b/playbooks/migrating-postgres-with-rubyrep.md
@@ -9,12 +9,7 @@ To set up database replication via [rubyrep](rubyrep.org), do the following:
 
 1) Create the new Postgres database and user
 
-2) Start a shell in the application with the new database connection and load the app schema with:
-```
-hokusai production run --env "DATABASE_URL=postgres://{new database credentials}" "bundle exec rake db:schema:load"
-```
-
-3) Backup and restore the existing database:
+2) Backup and restore the existing database:
 
 To backup, create the following Yaml file as `./hokusai/export-old-production.yml`
 ```
@@ -122,36 +117,34 @@ Apply with `hokusai [staging|production] create --filename ./hokusai/import-to-n
 
 Once complete, delete with `hokusai [staging|production] delete --filename ./hokusai/import-to-new-production.yml`
 
-4) Check the database schemas.
-  3a) If you want to download a dump of the current db to a local postgres, you can check schemas by running `rake db:schema:dump` locally, and checking in the diff in `db/schema.rb`.  You can also inspect the `schema_migrations` tables across the databases and compare to migrations.
-  3b) Log into the new database and note all foreign key constraints.  You can get foreign key constraints for each table with `\d+ table` or to see forign key constraints for all tables in the `public` schema, run:
-  ```
-  SELECT conrelid::regclass AS table_from
-       , conname
-       , pg_get_constraintdef(oid)
-  FROM   pg_constraint
-  WHERE  contype IN ('f')
-  AND    connamespace = 'public'::regnamespace  -- your schema here
-  ORDER  BY conrelid::regclass::text, contype DESC;
-  ```
+3) Log into the new database and note all foreign key constraints.  You can get foreign key constraints for each table with `\d+ table` or to see forign key constraints for all tables in the `public` schema, run:
+```
+SELECT conrelid::regclass AS table_from
+     , conname
+     , pg_get_constraintdef(oid)
+FROM   pg_constraint
+WHERE  contype IN ('f')
+AND    connamespace = 'public'::regnamespace  -- your schema here
+ORDER  BY conrelid::regclass::text, contype DESC;
+```
 
-  Example output:
-  ```
-        table_from     |       conname       |                    pg_get_constraintdef
-  --------------------+---------------------+-------------------------------------------------------------
-  foo                  | fk_rails_fbc9d01ca0 | FOREIGN KEY (bar_id) REFERENCES bar(id)
-  bar                  | fk_rails_80eb82ccbf | FOREIGN KEY (foo_id) REFERENCES foo(id) ON DELETE CASCADE
-  ```
+Example output:
+```
+      table_from     |       conname       |                    pg_get_constraintdef
+--------------------+---------------------+-------------------------------------------------------------
+foo                  | fk_rails_fbc9d01ca0 | FOREIGN KEY (bar_id) REFERENCES bar(id)
+bar                  | fk_rails_80eb82ccbf | FOREIGN KEY (foo_id) REFERENCES foo(id) ON DELETE CASCADE
+```
 
-  Save the constraints to later re-enable.
+Save the constraints to later re-enable.
 
-5) Disable all foreign key constraints, for example for tables `foo` and `bar` you would run:
+4) Disable all foreign key constraints, for example for tables `foo` and `bar` you would run:
 ```
 ALTER TABLE foo DROP CONSTRAINT fk_rails_fbc9d01ca0;
 ALTER TABLE bar DROP CONSTRAINT fk_rails_80eb82ccbf;
 ```
 
-6) Create the file `hokusai/rubyrep-config.yml` (Credentials here are redacted but they should be supplied to Kubernetes and this file should not be checked in!) The "left" configuration refers to the source database and the "right" refers to the target database.  Note that for rails apps we can ignore both `ar_internal_metadata` and `schema_migrations` tables.
+5) Create the file `hokusai/rubyrep-config.yml` (Credentials here are redacted but they should be supplied to Kubernetes and this file should not be checked in!) The "left" configuration refers to the source database and the "right" refers to the target database.  Note that for rails apps we can ignore both `ar_internal_metadata` and `schema_migrations` tables.
 
 ```
 ---
@@ -205,7 +198,7 @@ Create the configmap with:
 $ hokusai production create --filename ./hokusai/rubyrep-config.yml
 ```
 
-7) Create the file `./hokusai/rubyrep.yml`.  When the deployment is created, rubyrep will perform an initial sync.
+6) Create the file `./hokusai/rubyrep.yml`.  When the deployment is created, rubyrep will perform an initial sync.
 
 ```
 ---
@@ -252,9 +245,9 @@ Create the deployment with:
 $ hokusai production create --filename ./hokusai/rubyrep.yml
 ```
 
-8) When the database is synced and replication is active, we are ready to make a cutover.
+7) When the database is synced and replication is active, we are ready to make a cutover.
 
-  8a) Confirm that the databases are in-sync.  Run a rubyrep [scan command](http://www.rubyrep.org/scan_command.html) with:
+  7a) Confirm that the databases are in-sync.  Run a rubyrep [scan command](http://www.rubyrep.org/scan_command.html) with:
   ```
   kubectl --context [staging|production] run rubyrep-$(whoami) --restart=Never --rm -i --tty --overrides '
   {
@@ -290,29 +283,29 @@ $ hokusai production create --filename ./hokusai/rubyrep.yml
 
   If you want to see verbose logging from the Rubyrep deployment, uncomment the logger sections in the above configuration, and delete the existing rubyrep pod to roll it out.  You can tail then logs from the `{ myapp }-rubyrep` pod.
 
-  8b) To avoid race conditions regarding auto-incrementing primary keys, reset the table id sequences, leaving an offset for writes to the new database and headroom for replicated inserts from the old.  Check database / application write throughput to determine a reasonable value (i.e. writes/minute * 5) to leave room for the deployment rollout.  For, example, given an offset of `100`, run:
+  7b) To avoid race conditions regarding auto-incrementing primary keys, reset the table id sequences, leaving an offset for writes to the new database and headroom for replicated inserts from the old.  Check database / application write throughput to determine a reasonable value (i.e. writes/minute * 5) to leave room for the deployment rollout.  For, example, given an offset of `100`, run:
   ```
   SELECT setval('foo_id_seq', COALESCE((SELECT MAX(id)+100 FROM foo), 1), false);
   SELECT setval('bar_id_seq', COALESCE((SELECT MAX(id)+100 FROM bar), 1), false);
   ```
 
-  8c) Update the application's DATABASE_URL environment variable
+  7c) Update the application's DATABASE_URL environment variable
   ```
   hokusai production env set "DATABASE_URL={new database url}"
   ```
 
-  8d) Refresh the application
+  7d) Refresh the application
   ```
   hokusai production refresh
   ```
 
-  8e) Once the rollout is complete and all writes are going to the new database, Rubyrep's replication will work in reverse, propogating all changes from the new database back to the old.
+  7e) Once the rollout is complete and all writes are going to the new database, Rubyrep's replication will work in reverse, propogating all changes from the new database back to the old.
 
   Monitor your application and verify data integrity with another `scan` command.
 
   If you need to rollback, simply repeat steps 7b on the original database, then steps 7c reverting to the old `DATABASE_URL` and 7d.
 
-  8f) IMPORTANT! Re-enable foreign key constraints
+  7f) IMPORTANT! Re-enable foreign key constraints
   ```
   ALTER TABLE foo ADD CONSTRAINT fk_rails_fbc9d01ca0 FOREIGN KEY (bar_id) REFERENCES bar(id);
   ALTER TABLE bar ADD CONSTRAINT fk_rails_80eb82ccbf FOREIGN KEY (foo_id) REFERENCES foo(id) ON DELETE CASCADE;
@@ -320,13 +313,13 @@ $ hokusai production create --filename ./hokusai/rubyrep.yml
 
   If there are any unsatisfiable foreign key constraints, these commands will fail and you should roll back / check data integrity.
 
-  8g) Stop replication by deleting the Rubyrep deployment
+  7g) Stop replication by deleting the Rubyrep deployment
   ```
   $ hokusai production delete --filename ./hokusai/rubyrep.yml
   ```
 
 
-9) Finally, clean up Rubyrep's tables and triggers...
+8) Finally, clean up Rubyrep's tables and triggers...
 ```
 $ kubectl --context [staging|production] run rubyrep-$(whoami) --restart=Never --rm -i --tty --overrides '
 {

--- a/playbooks/migrating-postgres-with-rubyrep.md
+++ b/playbooks/migrating-postgres-with-rubyrep.md
@@ -107,6 +107,8 @@ spec:
           value: { app aws access key id }
         - name: AWS_SECRET_ACCESS_KEY
           value: { app secret access key }
+        - name: SWALLOW_ERRORS_ON_RESTORE
+          value: "1"
         image: artsy/pg-data-sync
         imagePullPolicy: Always
         name: { myapp }-data-import

--- a/playbooks/migrating-postgres-with-rubyrep.md
+++ b/playbooks/migrating-postgres-with-rubyrep.md
@@ -142,7 +142,7 @@ $ hokusai [staging|production] create --filename ./hokusai/rubyrep.yml
 
 7) When the database is synced and replication is active, we are ready to make a cutover.
 
-  7a) Confirm that the databases are in-sync.  Run a rubyrep scan with:
+  7a) Confirm that the databases are in-sync.  Run a rubyrep [scan command](http://www.rubyrep.org/scan_command.html) with:
   ```
   kubectl --context [staging|production] run rubyrep-$(whoami) --restart=Never --rm -i --tty --overrides '
   {
@@ -153,6 +153,7 @@ $ hokusai [staging|production] create --filename ./hokusai/rubyrep.yml
         {
           "name": "rubyrep",
           "image": "artsy/rubyrep",
+          "args": ["/rubyrep-2.0.1/rubyrep", "scan", "-c", "/mnt/default.conf", "--summary=detailed", "--detailed=diff"],
           "stdin": true,
           "stdinOnce": true,
           "tty": true,
@@ -170,7 +171,7 @@ $ hokusai [staging|production] create --filename ./hokusai/rubyrep.yml
         }
       }]
     }
-  }' --image artsy/rubyrep -- /rubyrep-2.0.1/rubyrep --verbose scan -c /mnt/default.conf
+  }' --image artsy/rubyrep
   ```
 
   The diff should show `0` in total for all tables.

--- a/playbooks/migrating-postgres-with-rubyrep.md
+++ b/playbooks/migrating-postgres-with-rubyrep.md
@@ -117,6 +117,15 @@ Apply with `hokusai [staging|production] create --filename ./hokusai/import-to-n
 
 Once complete, delete with `hokusai [staging|production] delete --filename ./hokusai/import-to-new-production.yml`
 
+Note: if you are unable to backup the old database and restore to the new via the `pg-data-sync` image (for instance in the case of differing Postgres major versions) you can load the app schema into the new database instead, and let RubyRep perform the migration.
+
+Start a shell in the application with the new database connection and load the app schema with:
+```
+hokusai production run --env "DATABASE_URL=postgres://{new database credentials}" "bundle exec rake db:schema:load"
+```
+
+However, be aware the RubyRep is known to deadlock in some cases when migrating large tables ( over 1Gb in size ) so skipping the initial dump and restore should only be used as a fallback!
+
 3) Log into the new database and note all foreign key constraints.  You can get foreign key constraints for each table with `\d+ table` or to see forign key constraints for all tables in the `public` schema, run:
 ```
 SELECT conrelid::regclass AS table_from


### PR DESCRIPTION
Playbook for migrating Postgres databases with [Rubyrep](http://rubyrep.org/) using our [Docker image](https://github.com/artsy/docker-images/tree/master/rubyrep)

