### PR TITLE
fix typo in playbooks/migrating-postgres-with-rubyrep.md

### DIFF
--- a/playbooks/migrating-postgres-with-rubyrep.md
+++ b/playbooks/migrating-postgres-with-rubyrep.md
@@ -266,7 +266,7 @@ $ hokusai [staging|production] create --filename ./hokusai/rubyrep.yml
         {
           "name": "rubyrep",
           "image": "artsy/rubyrep",
-          "args": ["/rubyrep-2.0.1/rubyrep", "sync", "-c", "/mnt/default.conf", "-s"],
+          "args": ["/rubyrep-2.0.1/rubyrep", "scan", "-c", "/mnt/default.conf", "-s"],
           "stdin": true,
           "stdinOnce": true,
           "tty": true,


### PR DESCRIPTION
`s/sync/scan`