### PR TITLE
Remove frontend practice updates

### DIFF
--- a/events/open-standup.md
+++ b/events/open-standup.md
@@ -56,7 +56,6 @@ _Hiring Updates_
 
 _Practice Updates_
 
-- Front-End:
 - Front-End iOS:
 - Platform:
 


### PR DESCRIPTION
Given that frontend practice has moved to an ad hoc meeting basis, let's remove the updates from the standup notes.