### PR TITLE
Update standup agenda

### DIFF
--- a/events/open-standup.md
+++ b/events/open-standup.md
@@ -46,7 +46,7 @@ _Props_
 
 -
 
-_Company Updates (VP of Engineering)_
+_Company Updates_
 
 -
 


### PR DESCRIPTION
Removing outdated (and unnecessary) title call out in agenda.
Company Updates should be sufficient.