### PR TITLE
Updates new dependency RFC template

### DIFF
--- a/.github/ISSUE_TEMPLATE/dependency-rfc.md
+++ b/.github/ISSUE_TEMPLATE/dependency-rfc.md
@@ -3,35 +3,41 @@ name: Dependency RFC
 about: Sample template for a dependency RFC
 ---
 
+<!--
+Hello Artsy Engineer 👋 Sometimes the best way to communicate an RFC for adding a new dependency is with a pull request! Feel free to copy the following template onto a pull request showing how you'd use the new dependency. Probably best to make it a small PR – just enough detail to help have a productive conversation.
+-->
+
 ### New Dependency
 
-Name: danger
+Name:
 
-URL: https://danger.systems
+URL:
 
-### Focus
+### Motivation
 
-Allows us to start writing checks for things like changelog requirements, or requiring tests to simplify code
-review
+<!--
+Describe why you'd like to add the dependency. Be as brief or detailed as you see fit. Remember that we're responsible for all the code we ship, even for our dependencies.
+-->
 
 ### Check List
 
-- [ ] Have read over the source code
-- [ ] Has had a release in the last year, or looks done and stable
+<!--
+This list isn't a list of must-have requirements. It is a tool to help our team have a productive conversation. You don't have to check all the boxes, but maybe use any unchecked boxes as a jumping-off point for the Motivation section.
+-->
+
+- [ ] Have you read over the source code?
+- [ ] Has had a release in the last year, or looks done and stable?
 - [ ] Could you fit this codebase in your head after reading the source?
 - [ ] Is this the stand-out obvious answer to a particular domain problem?
 - [ ] Do you expect your team to be the only people who know about this dependency?
-- [ ] Is this obviously being used in production by the maintainers, and thus battle-tested?
-- [ ] Does our bundle already include a (transitive) dependency that solves the problem and could we use that instead?
-- [ ] Do you feel well versed in the domain of this dependency and/or could maintain it if that needs to become an
-      option?
+- [ ] Is this obviously being used in production by the maintainers? Is it battle-tested?
+- [ ] Does our bundle already include a (transitive) dependency that solves the problem and could we use that
+      instead?
+- [ ] Do you feel well versed in the domain of this dependency and/or could you maintain it if that needs to become
+      an option?
 
 ### Alternatives
 
-- _Setting up Peril_
-
-  This is a bit too much to just jump to right now
-
-- _Rubocop_
-
-  Only works for ruby projects, and we have iOS / JS projects too
+<!--
+List any alternative dependencies you considered here, as well as a brief description of why you didn't go with them.
+-->

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -33,6 +33,7 @@ practice should be incorporated, submit a PR!
 | [How to give a good Informational](/playbooks/informationals.md#readme) | What are the steps needed to give someone a great experience. |
 | [Jira](/playbooks/jira.md#readme) | Working with Jira boards and tickets |
 | [Kubernetes](/playbooks/kubernetes.md#readme) | Deploying containerized applications at Artsy |
+| [Migrating Postgres with Rubyrep](/playbooks/migrating-postgres-with-rubyrep.md#readme) | How to migrate a Postgres to a new instance using Rubyrep |
 | [Migrating Redis](/playbooks/migrating-redis.md#readme) | How to migrate data between Redis instances. |
 | [Migrating Sidekiq](/playbooks/migrating-sidekiq.md#readme) | How to migrate Sidekiq to a new Redis instance |
 | [Open-sourcing a project](/playbooks/open-sourcing.md#readme) | How to take a private repo and make it open-source |

--- a/playbooks/technology_radar/artsy-tech-radar.csv
+++ b/playbooks/technology_radar/artsy-tech-radar.csv
@@ -49,6 +49,7 @@ Scala,hold,languages & frameworks,FALSE,
 Swift,hold,languages & frameworks,FALSE,
 AWS Lambda,hold,platforms,TRUE,
 Google cloud,hold,platforms,FALSE,
+Heroku,hold,platforms,FALSE,"We prefer kubernetes where we have shared solutions for authorization, logging, monitoring, alerting, scaling, and routing."
 Bug bounties,hold,techniques,FALSE,
 Hypermedia,hold,techniques,FALSE,"While discoverable and easy to consume, we've found hypermedia APIs inefficient to consume."
 Metaphysics' v1 schema,hold,techniques,TRUE,"The v1 schema is deprecated and should be considered frozen. Consumers should switch to v2 rather than make further modifications to v1."
@@ -60,4 +61,3 @@ MongoDB,hold,tools,FALSE,
 Pingdom,hold,tools,TRUE,
 Semaphore,hold,tools,FALSE,
 Travis CI,hold,tools,TRUE,
-Heroku,hold,platforms,FALSE,"We prefer kubernetes where we have shared solutions for authorization, logging, monitoring, alerting, scaling, and routing."


### PR DESCRIPTION
@sweir27 This is a follow-up from our conversation in #307. I've added inline HTML comments to the RFC markdown template so that the engineer opening the issue will see them in their issue-compose text input, but they won't be visible in the rendered markup. This is a technique I'm borrowing from [fastlane](https://raw.githubusercontent.com/fastlane/fastlane/master/.github/PULL_REQUEST_TEMPLATE.md).

I've tried to clarify the point of the checklist, as well as the RFC process itself. Happy to further amend based on feedback. There is some file churn from the pre-commit hook as well. 