### PR TITLE
Adds doc on interviewing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ We split this repo out into different sections, each one has a summary of what's
 | [Conference Notes](/conference-notes#readme) | Artsy Engineers' notes from attending conferences. |
 | [Engineering Culture](/culture#readme) | What makes Artsy Engineering tick? |
 | [Events at Artsy](/events#readme) | Documentation on regularly occurring events and meetings. |
+| [Hiring at Artsy](/hiring#readme) | How do we hire people |
 | [Onboarding Notes for New Engineers](/onboarding#readme) | Your first steps to being productive |
 | [Playbooks](/playbooks#readme) | Tips, procedures, and best practices |
 | [Engineering Practices](/practices#readme) | How do we handle cross-functional concerns. |
@@ -31,7 +32,11 @@ We split this repo out into different sections, each one has a summary of what's
 
 ### Product & Engineering Teams
 
-Artsy product engineering is organized in product teams. Each team has a _purpose_, eg. _"Help galleries get the most out of Artsy and run their business better"_, and Key Performance Indicators, or KPIs, eg. _"The number of artworks uploaded by partners."_ Each team has members with different responsibilities, including a _Project Manager_, a _Designer_, a _Technical Lead_ and _Engineers_, depending on size. Sometimes the same person wears multiple hats.
+Artsy product engineering is organized in product teams. Each team has a _purpose_, eg. _"Help galleries get the
+most out of Artsy and run their business better"_, and Key Performance Indicators, or KPIs, eg. _"The number of
+artworks uploaded by partners."_ Each team has members with different responsibilities, including a _Project
+Manager_, a _Designer_, a _Technical Lead_ and _Engineers_, depending on size. Sometimes the same person wears
+multiple hats.
 
 You can see this organization
 [in the Product section of Notion 🔑](https://www.notion.so/artsy/Product-470238180cf94c87906ef1d3ee259e05).
@@ -49,7 +54,8 @@ Engineers typically work on a product team and may also belong to an _Engineerin
   - Team leads: [Justin](https://github.com/zephraph) (web) / [Ash](https://github.com/ashfurrow) (iOS)
   - Slack: [#front-end](https://artsy.slack.com/messages/front-end) 🔒,
     [#front-end-ios](https://artsy.slack.com/messages/front-end-ios) 🔒
-  - [Front-end web Practice Overview](practices/front-end.md), [Front-end iOS Practice Overview](practices/front-end-ios.md)
+  - [Front-end web Practice Overview](practices/front-end.md),
+    [Front-end iOS Practice Overview](practices/front-end-ios.md)
 
 ## Support
 
@@ -65,16 +71,13 @@ If you are on call or asked to fix an immediate issue, check out our doc on
   <img align="left" src="https://avatars2.githubusercontent.com/u/546231?s=200&v=4"/>
 </a>
 
-This project is the work of engineers at [Artsy][footer_website], the world's
-leading and largest online art marketplace and platform for discovering art.
-One of our core [Engineering Principles][footer_principles] is being [Open
-Source by Default][footer_open] which means we strive to share as many details
-of our work as possible.
+This project is the work of engineers at [Artsy][footer_website], the world's leading and largest online art
+marketplace and platform for discovering art. One of our core [Engineering Principles][footer_principles] is being
+[Open Source by Default][footer_open] which means we strive to share as many details of our work as possible.
 
-You can learn more about this work from [our blog][footer_blog] and by following
-[@ArtsyOpenSource][footer_twitter] or explore our public data by checking out
-[our API][footer_api]. If you're interested in a career at Artsy, read through
-our [job postings][footer_jobs]!
+You can learn more about this work from [our blog][footer_blog] and by following [@ArtsyOpenSource][footer_twitter]
+or explore our public data by checking out [our API][footer_api]. If you're interested in a career at Artsy, read
+through our [job postings][footer_jobs]!
 
 [footer_website]: https://www.artsy.net/
 [footer_principles]: culture/engineering-principles.md

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ We split this repo out into different sections, each one has a summary of what's
 
 Artsy product engineering is organized in product teams. Each team has a _purpose_, eg. _"Help galleries get the
 most out of Artsy and run their business better"_, and Key Performance Indicators, or KPIs, eg. _"The number of
-artworks uploaded by partners."_ Each team has members with different responsibilities, including a _Project
+artworks uploaded by partners."_ Each team has members with different responsibilities, including a _Product
 Manager_, a _Designer_, a _Technical Lead_ and _Engineers_, depending on size. Sometimes the same person wears
 multiple hats.
 

--- a/culture/engineering-principles.md
+++ b/culture/engineering-principles.md
@@ -160,8 +160,8 @@ success on automation via documentation for recurring meetings.
 
 ### Leverage Your Impact
 
-We built an large reputation for our size as an engineering team via these principles. This gives internal
-engineers the ability to move local impact to a larger communal impact.
+We built a large reputation for our size as an engineering team via these principles. This gives internal engineers
+the ability to move local impact to a larger communal impact.
 
 Consider ways in which you can expand the scope of impact for your time:
 

--- a/hiring/README.md
+++ b/hiring/README.md
@@ -1,0 +1,11 @@
+### Hiring
+
+Documentation on our hiring process
+
+<!-- prettier-ignore-start -->
+<!-- start_toc -->
+| Doc | Overview |
+|--|--|
+| [Interviewing @ Artsy](/hiring/interviewing.md#readme) | An overview of our interview process |
+<!-- end_toc -->
+<!-- prettier-ignore-end -->

--- a/hiring/interviewing.md
+++ b/hiring/interviewing.md
@@ -1,0 +1,112 @@
+---
+title: "Interviewing @ Artsy"
+description: An overview of our interview process
+---
+
+## What to expect from an Artsy interview
+
+We're excited that you've decided to interview for a job at Artsy! This document will cover our standard interview
+process. Our goal is to give you the information you need to feel prepared.
+
+We'll update this as often as we can when things change, but note that the details may shift slightly. Our
+Recruitment team will be available to answer any questions you may have throughout the hiring process!
+
+This guide is tailored to our standard interviews for the IC3-IC5 levels on
+[our ladder](/careers/ladder.md#readme). The content of the interviews may change slightly for other levels, but
+the ethos will be the same.
+
+### Phone screens
+
+As a very first step, you’ll speak with one of our recruiters and perhaps an engineering manager. These
+conversations are a way for us to learn more about you, what motivates you, and gauge whether Artsy and the
+opportunity is a good fit for your career goals.
+
+**How to prepare** Be prepared to speak to the work you’ve accomplished on your resume—we may ask you to describe a
+recent project and/or specific technologies you’ve used in the past. Also make sure to come prepared with questions
+to ask your interviewer. Remember, this is also for _you_ to make sure Artsy would be a good fit!
+
+### "On-site" Interview
+
+During your "on-site", you will participate in four 30 minute interviews, and one 60 minute interview:
+
+#### 1. Hiring Manager
+
+This interview is with the hiring manager for the role. The hiring manager will be an Engineering Manager on the
+team, and in _most_ cases, will be your people manager if you are to join Artsy.
+
+This interview focuses on the capabilities described in [our engineering ladder](/careers/ladder.md#readme). You
+will not be asked to whiteboard, but be prepared to talk about past experiences working on teams or projects.
+
+#### 2. Peer (Engineer)
+
+This interview will be with an engineer. We have a semi-fluid team structure, so this person may or may not be on
+the same team as this role.
+
+The goal of this interview is to learn about your experience collaborating with other engineers. Like the hiring
+manager interview, this is non-technical but be prepared to discuss past experiences.
+
+#### 3. Peer (Non-Engineer)
+
+This interview will be with a member of our Product, Design or Data teams.
+
+Similar to the Peer (Engineer) interview above, this is non-technical but you should be prepared to discuss past
+experiences working cross-collaboratively.
+
+#### 4. Technical Fluency
+
+This interview will be with an engineer. The focus of this interview varies for different levels and specialities.
+Most likely, the person you interview with will be at the same (or higher) level than the one you are interviewing
+for and have expertise in the domain.
+
+You will not be asked to code but we will dig into the technical details of projects you've worked on. In general,
+we care more about hearing how you think through problems vs. whether you're familiar with a specific technology.
+
+Some advice: dig into the details! Talk about how you approached problems and why. We like to hear your thought
+process but also understand if you need a few moments to think before answering-- let us know if this is the case!
+
+#### 5. System Design
+
+This interview is with an engineer, and lasts an hour. Here, you will be presented a scenario and asked to design a
+system\*. You are expected to take us through your thought process and may use a whiteboard (or equivalent in a
+remote setup) to explain your work, but you will not be asked to code anything.
+
+In this interview, we're evaluating the following key areas:
+
+- Systems thinking: Are you able to think holistically about the problem and dig into details.
+- Decision-making: What factors are you employing when making decisions. Can you explain why you chose X or Y?
+- Communication: We want to hear your thought-process and assumptions as you make them.
+
+\*"System" is used generically here to represent a chunk of an ecosystem. We tailor the prompt to the specific
+role. (For example: if it's an iOS role, you may be asked to design a feature in an iOS app. We're not trying to
+trick you here!)
+
+### References
+
+After the interview loop, we will connect with your professional references.
+
+References are an important part of Artsy's hiring strategy across all roles. We’ll ask for three references—these
+should be a combination of direct managers and close collaborators. If you’re unable to provide three (i.e. if
+you’ve been in the same job your whole career), let us know!
+
+During these calls, we'll ask your references in-depth questions about their experience working with you. See
+[this blog post on hiring](https://artsy.github.io/blog/2019/01/23/artsy-engineering-hiring/) for more details.
+
+### General Tips
+
+- Feel free to take a few moments of quiet time if you need them throughout the interview, but make sure you are
+  also _thinking out loud_. By letting us hear your thought-process, we can also help guide you towards the topics
+  we’re interested in hearing about most!
+- Bring questions for your interviewers. Use the opportunity to make sure that Artsy is the type of company that
+  you'd be excited to work at. Feel free to ask about anything, including: company goals and values, team history,
+  etc.
+- You are not required to have a deep knowledge of Artsy's product or engineering team before interviewing, but it
+  can be helpful to do some research ahead of time as a way to frame your questions or discussion. We recommend
+  poking around artsy.net, looking at our engineering blog, and checking out our
+  [Artsy in a Nutshell](/culture/what-is-artsy.md#readme) doc in this repo.
+
+### Additional Resources
+
+- [This blog post](https://artsy.github.io/blog/2019/01/23/artsy-engineering-hiring/) on our hiring process written
+  in January of 2019 is still relevant! Details around the exact structure of our interviews is outdated (refer to
+  this doc for up-to-date information), but the general approach is the same.
+-

--- a/hiring/interviewing.md
+++ b/hiring/interviewing.md
@@ -11,11 +11,17 @@ process. Our goal is to give you the information you need to feel prepared.
 We'll update this as often as we can when things change, but note that the details may shift slightly. Our
 Recruitment team will be available to answer any questions you may have throughout the hiring process!
 
-This guide is tailored to our standard interviews for the IC3-IC5 levels on
-[our ladder](/careers/ladder.md#readme). The content of the interviews may change slightly for other levels, but
-the ethos will be the same.
+This guide is tailored to our standard interviews for most individual-contributor roles. The content of the
+interviews may change slightly based on the level, but the ethos will be the same.
 
-### Phone screens
+At a high level, our interviews have three phases:
+
+- [**Phone screen**](#phone-screen): Short chats with a recruiter and (often) an engineering manager.
+- [**On-site**](#"on-site"-interview): Our standard interview loop. Includes four interviews with engineers and
+  non-engineers.
+- [**References**](#references): Three professional references (this part is the same for interviews across Artsy).
+
+### Phone Screen
 
 As a very first step, you’ll speak with one of our recruiters and perhaps an engineering manager. These
 conversations are a way for us to learn more about you, what motivates you, and gauge whether Artsy and the
@@ -27,7 +33,7 @@ to ask your interviewer. Remember, this is also for _you_ to make sure Artsy wou
 
 ### "On-site" Interview
 
-During your "on-site", you will participate in four 30 minute interviews, and one 60 minute interview:
+During your "on-site," you will usually participate in four 30 minute interviews and one 60 minute interview:
 
 #### 1. Hiring Manager
 
@@ -50,19 +56,19 @@ manager interview, this is non-technical but be prepared to discuss past experie
 This interview will be with a member of our Product, Design or Data teams.
 
 Similar to the Peer (Engineer) interview above, this is non-technical but you should be prepared to discuss past
-experiences working cross-collaboratively.
+experiences and especially collaborations with non-technical colleagues.
 
 #### 4. Technical Fluency
 
-This interview will be with an engineer. The focus of this interview varies for different levels and specialities.
-Most likely, the person you interview with will be at the same (or higher) level than the one you are interviewing
-for and have expertise in the domain.
+This interview will be with an engineer. The focus of this interview varies for different levels and specialties.
+Most likely, the person you interview with will be someone with experience relevant to the role.
 
 You will not be asked to code but we will dig into the technical details of projects you've worked on. In general,
 we care more about hearing how you think through problems vs. whether you're familiar with a specific technology.
 
 Some advice: dig into the details! Talk about how you approached problems and why. We like to hear your thought
-process but also understand if you need a few moments to think before answering-- let us know if this is the case!
+process but also understand if you need a few moments to think before answering-- let us know if this is the case,
+and don't be afraid to ask clarifying questions!
 
 #### 5. System Design
 
@@ -72,21 +78,22 @@ remote setup) to explain your work, but you will not be asked to code anything.
 
 In this interview, we're evaluating the following key areas:
 
-- Systems thinking: Are you able to think holistically about the problem and dig into details.
-- Decision-making: What factors are you employing when making decisions. Can you explain why you chose X or Y?
+- Systems thinking: Are you able to both think holistically about the problem and dig into details?
+- Decision-making: What factors are you employing when making decisions? Can you explain why you chose X or Y?
 - Communication: We want to hear your thought-process and assumptions as you make them.
 
 \*"System" is used generically here to represent a chunk of an ecosystem. We tailor the prompt to the specific
-role. (For example: if it's an iOS role, you may be asked to design a feature in an iOS app. We're not trying to
-trick you here!)
+role, so for example if it's an iOS role, you may be asked to design a feature in an iOS app; if it's a full stack
+role, it could be something like a simple architecture for notifications. We're not trying to trick you here or
+catch you out, we just want hear how you leverage your knowledge and experience.
 
 ### References
 
-After the interview loop, we will connect with your professional references.
+Based on feedback from these interviews, we'll ask to connect with your professional references.
 
 References are an important part of Artsy's hiring strategy across all roles. We’ll ask for three references—these
 should be a combination of direct managers and close collaborators. If you’re unable to provide three (i.e. if
-you’ve been in the same job your whole career), let us know!
+you’ve been in the same job your whole career), let us know and we'll figure something out!
 
 During these calls, we'll ask your references in-depth questions about their experience working with you. See
 [this blog post on hiring](https://artsy.github.io/blog/2019/01/23/artsy-engineering-hiring/) for more details.
@@ -101,12 +108,11 @@ During these calls, we'll ask your references in-depth questions about their exp
   etc.
 - You are not required to have a deep knowledge of Artsy's product or engineering team before interviewing, but it
   can be helpful to do some research ahead of time as a way to frame your questions or discussion. We recommend
-  poking around artsy.net, looking at our engineering blog, and checking out our
-  [Artsy in a Nutshell](/culture/what-is-artsy.md#readme) doc in this repo.
+  poking around [artsy.net](https://www.artsy.net/), looking at our [engineering blog](https://artsy.github.io/),
+  and checking out our [Artsy in a Nutshell](/culture/what-is-artsy.md#readme) doc in this repo.
 
 ### Additional Resources
 
 - [This blog post](https://artsy.github.io/blog/2019/01/23/artsy-engineering-hiring/) on our hiring process written
   in January of 2019 is still relevant! Details around the exact structure of our interviews is outdated (refer to
   this doc for up-to-date information), but the general approach is the same.
--

--- a/hiring/summary.json
+++ b/hiring/summary.json
@@ -1,0 +1,4 @@
+{
+  "title": "Hiring at Artsy",
+  "description": "How do we hire people"
+}


### PR DESCRIPTION
This PR adds a document on our interview process! The goal is for this to be public and kept up-to-date so we can share with candidates before and throughout our interview process.

This builds off of a working session with @jonallured and @xtina-starr ✨ and is influenced by [this awesome blog post](https://artsy.github.io/blog/2019/01/23/artsy-engineering-hiring/) from Artsy engineers and [this other awesome blog post](https://jvns.ca/blog/2020/06/30/tell-candidates-what-to-expect-from-your-job-interviews/) about the importance of being transparent in interviewing.