### PR TITLE
Update deployments playbook to reflect more consistent process and mature tools

### DIFF
--- a/playbooks/support/README.md
+++ b/playbooks/support/README.md
@@ -40,12 +40,12 @@ sprints. See [below](#examples) for some common examples.
 ## Wait!
 
 If you are new to on-call or looking for a refresher, we recommend watching the
-[on-call onboarding session](https://drive.google.com/file/d/1nGtNLCwP9zOBxhocnAFI-Ua1xs7eJYyD/view?usp=sharing) 🔒 we
-ran on June 13, 2019 which talks through your responsibilities as an on-call engineer.
+[on-call onboarding session](https://drive.google.com/file/d/1nGtNLCwP9zOBxhocnAFI-Ua1xs7eJYyD/view?usp=sharing) 🔒
+we ran on June 13, 2019 which talks through your responsibilities as an on-call engineer.
 
-Note: The [onboarding session](https://drive.google.com/file/d/1nGtNLCwP9zOBxhocnAFI-Ua1xs7eJYyD/view?usp=sharing) 🔒
-we ran on March 8, 2019 is still largely relevant, but includes instructions for tracking incidents via Jira Ops,
-which is now outdated. See the link above for instructions for how to use OpsGenie for this process.
+Note: The [onboarding session](https://drive.google.com/file/d/1nGtNLCwP9zOBxhocnAFI-Ua1xs7eJYyD/view?usp=sharing)
+🔒 we ran on March 8, 2019 is still largely relevant, but includes instructions for tracking incidents via Jira
+Ops, which is now outdated. See the link above for instructions for how to use OpsGenie for this process.
 
 ## Process Overview
 


### PR DESCRIPTION
This doc was last updated during the early part of our transition to more consistent CI and release tooling. Happy to say we can drop most of it finally, and instead point readers (new engineers, especially) to the templates and tools that will mostly do the right, standard thing.

Depends on doc updates pending in https://github.com/artsy/horizon/pull/221.