### PR TITLE
[Radar] "Hold" Backends for Frontends in favor of a unified GraphQL schema

### DIFF
--- a/playbooks/engineer-workflow.md
+++ b/playbooks/engineer-workflow.md
@@ -35,8 +35,8 @@ README if you want to know who to start asking questions to.
 
 ### Working in branches
 
-After using the [fork-and-branch](https://blog.scottlowe.org/2015/01/27/using-fork-branch-git-workflow/) workflow 
-for several years, Artsy teams now prefer to work in branches directly on the main repository. This means that 
+After using the [fork-and-branch](https://blog.scottlowe.org/2015/01/27/using-fork-branch-git-workflow/) workflow
+for several years, Artsy teams now prefer to work in branches directly on the main repository. This means that
 developers should clone the repo, create a branch from `master` for the work they are doing, and then push that
 branch back to the main repo. [Pull requests](#pull-requests) are then made from the working branch back to the
 `master` branch.

--- a/playbooks/support/README.md
+++ b/playbooks/support/README.md
@@ -78,6 +78,7 @@ favorable timezones where appropriate. See our [On-Call SLO document](on-call-sl
 the coverage we currently promise.
 
 ## Preparing for your on-call shift
+
 - Make sure you have read all the above.
 - [Set up Slack Notifications](https://github.com/artsy/README/blob/master/playbooks/support/slack-notifications.md)
 

--- a/playbooks/technology_radar/artsy-tech-radar.csv
+++ b/playbooks/technology_radar/artsy-tech-radar.csv
@@ -50,6 +50,7 @@ Swift,hold,languages & frameworks,FALSE,
 AWS Lambda,hold,platforms,TRUE,
 Google cloud,hold,platforms,FALSE,
 Heroku,hold,platforms,FALSE,"We prefer kubernetes where we have shared solutions for authorization, logging, monitoring, alerting, scaling, and routing."
+Backends for Frontends,hold,techniques,TRUE,"Rather than tailor backends to particular product surfaces or teams, we strive to serve clients via a unified GraphQL schema, reconciling or disambiguating domain concepts as necessary."
 Bug bounties,hold,techniques,FALSE,
 Hypermedia,hold,techniques,FALSE,"While discoverable and easy to consume, we've found hypermedia APIs inefficient to consume."
 Metaphysics' v1 schema,hold,techniques,TRUE,"The v1 schema is deprecated and should be considered frozen. Consumers should switch to v2 rather than make further modifications to v1."


### PR DESCRIPTION
Tiny change, big write-up.

Building and maintaining our shared GraphQL orchestration layer ([Metaphysics](https://github.com/artsy/metaphysics)) has been a growing challenge, especially as multiple teams have tried to extend and release it safely across independent work streams. The Platform practice has been considering the alternative [Backends for Frontends](https://www.thoughtworks.com/radar/techniques/bff-backend-for-frontends) pattern that addresses some of these challenges by separating more focused back-ends for each product or product area. After lots of thinking and discussion, I propose that we **hold** further consideration of that pattern and instead rededicate ourselves to making our shared service and schema as powerful and robust as possible.

### Rationale:

* BFFs optimize for long-lived teams with clear system ownership, but our teams and staffing have tended to change often in line with business priorities. I think we gain more from the domain awareness and staffing flexibility of sharing code than we lose in cognitive overhead.
* Our product capabilities have tended to converge or recombine over time. Collections can become consignment submissions which can become auction lots. Inquiry inboxes expanded from partners to collectors.
* Our product audiences are also not so clear-cut. Live auctions went from being operated by administrators to partners. Art dealers can be partners as well as buyers. Sales can be associated with auction houses or galleries or Artsy itself. Any of these boundaries, if it were used to separate back-ends, would have broken down at some point.
* The strong trend in our roadmap has been towards achieving _parity_ between product surfaces rather than building different capabilities for different clients. (Extending desktop web functionality to mobile web, web functionality to iOS, and iOS to Android.)
* Sharing a single back-end demands more careful up-front design, modeling, and naming. I suggest that this is _time well spent_, and creates opportunities and velocity in the long term.
* While Metaphysics and its primary consumer, Force, _are_ large and complex, they can each be vastly simplified _without_ being carved into pieces. Force can consolidate its 3 languages and page architectures to 1. Metaphysics can drop its v1 schema. Both of these efforts are already in progress.
* We've invested in promising tools to coordinate our work on a shared orchestration layer like [deploy blocks](https://github.com/artsy/README/blob/master/playbooks/deployments.md#tools), [pre-release guards](https://github.com/artsy/orbs/blob/master/src/release/release.yml), and [automated schema pushes](https://github.com/artsy/metaphysics/blob/master/scripts/push-schema-changes.js).

### Caveats:

This recommendation is only as good as our thinking and technology up until this point. As we encounter more lessons ourselves or different technology or insight is available in the community, obviously this is subject to change.

See also the Platform practice's [pre-reading](https://www.notion.so/artsy/Would-Artsy-benefit-from-dividing-Metaphysics-into-separate-client-focused-services-ee7d4a1be9a44ed6bb596443107d4192) and [notes](https://www.notion.so/artsy/2020-09-03-Platform-Practice-Meeting-Notes-4b6e5b0966b345bface2a3437536f487).
