### PR TITLE
RFC: Adds suggestions for Code Reviewing

### DIFF
--- a/playbooks/engineer-workflow.md
+++ b/playbooks/engineer-workflow.md
@@ -12,6 +12,7 @@ description: How we work together
     - [Fork-and-branch](#fork-and-branch)
     - [Commits](#commits)
     - [Pull requests](#pull-requests)
+    - [Code Reviews](#code-reviews)
     - [Testing](#testing)
     - [Deployment](#deployment)
   - [Continuous improvement](#continuous-improvement)
@@ -141,6 +142,15 @@ Further reading:
 - [On empathy and pull requests](https://slack.engineering/on-empathy-pull-requests-979e4257d158)
 - [Rules of communicating at GitHub](https://ben.balter.com/2014/11/06/rules-of-communicating-at-github/)
 - [RFC on defining PR roles at Artsy](https://github.com/artsy/README/issues/177)
+
+### Code Reviews
+
+The best PR comments are clear in their intention. While we don't mandate that PR comments follow any specific
+format, some people have found it helpful to adopt the standards outlined in
+[Conventional Comments](https://conventionalcomments.org).
+
+In particular, we encourage the use of `blocking` and `non-blocking` to signal whether or not a question or comment
+should be resolved before merging.
 
 ### Testing
 

--- a/playbooks/support/README.md
+++ b/playbooks/support/README.md
@@ -40,12 +40,12 @@ sprints. See [below](#examples) for some common examples.
 ## Wait!
 
 If you are new to on-call or looking for a refresher, we recommend watching the
-[on-call onboarding session](https://drive.google.com/file/d/1nGtNLCwP9zOBxhocnAFI-Ua1xs7eJYyD/view?usp=sharing) 🔒 we
-ran on June 13, 2019 which talks through your responsibilities as an on-call engineer.
+[on-call onboarding session](https://drive.google.com/file/d/1nGtNLCwP9zOBxhocnAFI-Ua1xs7eJYyD/view?usp=sharing) 🔒
+we ran on June 13, 2019 which talks through your responsibilities as an on-call engineer.
 
-Note: The [onboarding session](https://drive.google.com/file/d/1nGtNLCwP9zOBxhocnAFI-Ua1xs7eJYyD/view?usp=sharing) 🔒
-we ran on March 8, 2019 is still largely relevant, but includes instructions for tracking incidents via Jira Ops,
-which is now outdated. See the link above for instructions for how to use OpsGenie for this process.
+Note: The [onboarding session](https://drive.google.com/file/d/1nGtNLCwP9zOBxhocnAFI-Ua1xs7eJYyD/view?usp=sharing)
+🔒 we ran on March 8, 2019 is still largely relevant, but includes instructions for tracking incidents via Jira
+Ops, which is now outdated. See the link above for instructions for how to use OpsGenie for this process.
 
 ## Process Overview
 


### PR DESCRIPTION
## Context
Teams (and individuals) have been experimenting with adding more clarity around their PR comments. Most recently, this manifested in some teams trying out [Conventional Comments](https://conventionalcomments.org) guidelines.

However, it can be jarring or confusing to see conventional comments-style code review labels without explanation. See discussion (and the impetus for this RFC!) in [this slack thread](https://artsy.slack.com/archives/C02BC3HEJ/p1598380026075800).

While I don't believe we need to require code review comments to follow any particular standard format at this time, I do think it would be helpful to reference Conventional Comments and provide some suggestions for quality code reviews.

If we find that code review comments are consistently low-quality or causing confusion, we can certainly revisit how codified this process should be on the team!

## Proposal
Merge this PR, which provides _some_ guidance for code review comments, and a section that can be further expanded in the future.