### PR TITLE
clarify ONBOARDING MENTORS role

### DIFF
--- a/onboarding/mentors.md
+++ b/onboarding/mentors.md
@@ -6,23 +6,63 @@ description: How to be an effective mentor of a new hire
 # Mentorship at Artsy
 
 ## Why Mentor
-One of Artsy's core values is that [People are Paramount](/culture/what-is-artsy.md#people-are-paramount). As a company we try to meet this in a number of ways, from all the work of People Ops to Ongoing development conversations between employees and managers. As an engineering team we also try to reflect this value by encouraging mentoring among peers.
 
-What does this look like in practice? In an ideal world it would be automatic and spontaneous between every member of the team. Some of our [engineering principles](https://github.com/artsy/README/blob/master/culture/engineering-principles.md#readme) appeal explicitly to this ideal - **Psychological Safety**, **Leverage Your Impact**, **De-silo Engineers** and **Being Nice is Nice** stand out - while others like **Open Source by Default** and **Incremental Revolution**, while technical on the surface have clear analogues in how we work together. In practice we understand that all of these ideals require intentional work and iteration between people to make them reality. Artsy mentors, assigned when a new engineer joins the team, work to bridge that gap.
+We are proud of our
+[engineering principles](https://github.com/artsy/README/blob/master/culture/engineering-principles.md#readme) and
+team culture, from its commitment to excellence in software development to its impact on the wider software
+engineering community. Of course, no culture is static; rather than a one-time goal it is something that takes work
+to curate, maintain and protect. We recognize that all of these ideals require intentional work and iteration
+between people to make them reality. One way we work to maintain and grow this culture is through mentorship.
 
-## What makes a good mentor
-The role of a mentor is purposely different from that of a manager or technical lead, and that role shifts to accommodate the needs of a team member. There may be multiple overlapping descriptions - a mentor may be someone who
-- *Facilitates onboarding*: Simply someone who can help a new hire smooth out the bumps of getting onboarded.
-- *Knows how things work*: From a non-judgmental sounding board for [<strike>stupid</strike> questions](#simple-answers-to-common-questions) to someone who can simply help find the best point person or stakeholder for a project.
-- *Facilitates career development*: From apprenticeship to pointing someone in the direction of an article, project or pair where they can learn something new, mentoring pairs can help uncover or set new goals and offer help in meeting them.
+Although mentorship can occur in many forms, currently on the Artsy engineering team our only formal mentorship
+program is for new hires. Although both the company and engineering team have programs that fall under the umbrella
+of _mentorship, career development_ and _education_, this doc will focus on mentorship in the context of onboarding
+to the engineering team.
 
-It's up to the mentoring pair to find what works best for them and to ensure the relationship evolves over time to remain useful.
+## The Onboarding Mentor
 
-## How to mentor
-*Moving from the abstract to the concrete:*
+Each new engineering hire is assigned an _Onboarding mentor_ are by their manager. Onboarding mentors are not
+managers or teachers, but exist to help new engineers - _regardless of past experience_ - become confident,
+comfortable members of the team. An onboarding mentor acts as a new hire's perhaps most consistent peer (and
+**non-manager**) throughout the sprint rotation process. **As an onboarding mentor, you are expected to**
 
-### Your first day
-- Keep tabs on your mentee's schedule. Their first day will be full of paperwork and meetings with People Ops but some good tasks for a mentor:
+- Support and guide your mentee at least through the first 3 months. Expect that this will take a bit of your time,
+  at least 4-8 hours per week.
+- Schedule at least one meeting per week to check in with your mentee
+- Be an available pair when your mentee gets stuck
+- Provide a safe space for sounding other questions and concerns (though _not_ as a replacement for People Ops)
+- Be a source of consistency throughout their onboarding team sprint rotations
+
+### How to be an onboarding mentor
+
+The role of a mentor is purposely different from that of a manager or technical lead, and that role shifts to
+accommodate the needs of a team member. It's up to the mentoring pair to find what works best for them and to
+ensure the relationship evolves over time to remain useful.
+
+#### What to do?
+
+1-2 meetings a week is not going to fill your time, and in a vacuum will probably not be a very productive use of
+your time. A menu of possible ideas for extracurriculars:
+
+- Help set up a new repository or language tooling
+- Attend an optional meeting together:
+  - office hours
+  - an engineering practice
+  - peer learning working group
+- Draft a blog post together
+- Update documentation
+- Take the opportunity to learn from your mentee about their current sprint rotation work - there's a good chance
+  you have no idea what that team is up to
+- Share and discuss an article from the world of technology
+- Just Hack
+
+#### A hypothetical onboarding mentor's agenda
+
+_TODO: Update for 2020_  
+**Your first day**
+
+- Keep tabs on your mentee's schedule. Their first day will be full of paperwork and meetings with People Ops but
+  some good tasks for a mentor:
   - Introduce yourself
   - Set a time for an [introductory coffee or tea](#your-first-meeting)
   - Get in touch with the mentee's manager
@@ -31,53 +71,83 @@ It's up to the mentoring pair to find what works best for them and to ensure the
     - Their manager
     - Their team lead
     - Artsy atlas, calendars, benefit websites, mail filters, Jira and Github management tools...
-  
 
-### Your first meeting
+**Your first meeting**
+
 Get to know each other. This can be a nice, casual conversation. Focus on active listening.
+
 - Talk about your own history at and before joining Artsy
 - Where are they coming from?
-  - If they will be remote, where are they from? What is it like there & what works for them in terms of remote work?
+  - If they will be remote, where are they from? What is it like there & what works for them in terms of remote
+    work?
   - Are they new in town? Where do they live, for how long? Just have a normal conversation.
 - Prior experience with our [technology stacks](/playbooks/technology-choices.md) (and others)
 - Other relevant past experience, particularly 'soft skills' that might seem orthogonal to writing code
-- Are they using the [onboarding checklist](https://github.com/artsy/README/blob/master/.github/ISSUE_TEMPLATE/engineering-onboarding.md)? If so, check in on where they are and offer to be a resource on things there. Some tasks might stand out as good things to do in between People Ops meetings, while working nearby each other or to pair on.
+- Are they using the
+  [onboarding checklist](https://github.com/artsy/README/blob/master/.github/ISSUE_TEMPLATE/engineering-onboarding.md)?
+  If so, check in on where they are and offer to be a resource on things there. Some tasks might stand out as good
+  things to do in between People Ops meetings, while working nearby each other or to pair on.
 
-### Your first week
-- Check in to make sure your onboardee is moving forward in their checklist. Common stumbling areas include stale steps in the developer setup and getting invited to myriad organizations, lists and websites (slack, jira, github, notion, heroku, aws+hokusai, zeplin, ...)
+**Your first week**
+
+- Check in to make sure your onboardee is moving forward in their checklist. Common stumbling areas include stale
+  steps in the developer setup and getting invited to myriad organizations, lists and websites (slack, jira,
+  github, notion, heroku, aws+hokusai, zeplin, ...)
 - Look for chances to pair or work alongside one another throughout the week.
-  - If their early work hasn't exposed them to `artsy/gravity`, consider pairing on something trivial or just setting it up, breaking and fixing a test.
+  - If their early work hasn't exposed them to `artsy/gravity`, consider pairing on something trivial or just
+    setting it up, breaking and fixing a test.
   - If they haven't set up hokusai yet, consider pairing on that.
-- Try to have another meeting towards the end of the week- **especially** if they are leaving New York. Revisit things you talked about in the first meeting and look for areas that could have gone better. Consider amending relevant documents like this one.
+- Try to have another meeting towards the end of the week- **especially** if they are leaving New York. Revisit
+  things you talked about in the first meeting and look for areas that could have gone better. Consider amending
+  relevant documents like this one.
 
-### Your first year
-- New hires usually begin with a sprint-by-sprint rotation through our teams, a whirlwind that can last upwards of 2 months. It's good to check in with your mentee during this time.
+**Your first year**
+
+- New hires usually begin with a sprint-by-sprint rotation through our teams, a whirlwind that can last upwards of
+  2 months. It's good to check in with your mentee during this time.
 - Consider reaching out to other mentors as well
 - Periodically check in with yourself on what you think you know about your mentee:
-  - How are they feeling at work? It's good to be aware (if you can) of comfort level, new technologies and more dynamic pieces of how they are getting situated at Artsy.
-  - Are there any opportunities to pair together (or for them to pair with someone else) on a new technology or domain area?
-- Many mentoring pairs continue scheduling semi-weekly coffee chats in the weeks and months going forward. As the relationship becomes less formal these can be great to keep in touch with a team member you have a special relationship with!
+  - How are they feeling at work? It's good to be aware (if you can) of comfort level, new technologies and more
+    dynamic pieces of how they are getting situated at Artsy.
+  - Are there any opportunities to pair together (or for them to pair with someone else) on a new technology or
+    domain area?
+- Many mentoring pairs continue scheduling semi-weekly coffee chats in the weeks and months going forward. As the
+  relationship becomes less formal these can be great to keep in touch with a team member you have a special
+  relationship with!
 
 ## Footnotes
+
 #### Additional Context
+
 - [Blog post on professional development at Artsy](http://artsy.github.io/blog/2016/09/22/professional-development-at-artsy-engineering/)
 - [Onboarding Home](/onboarding)
-- There exist other conceptions of mentorship- an apprenticeship for example, or the more long-term relationship between an experienced practitioner 'championing' a new developer as they enter the industry. This guide isn't meant to replace or erase any other definition, and is strictly about mentorship 'at Artsy.'
-- Related to mentors but generally coming from a non-engineering role, at Artsy we offer each new team member a *spirit guide*— a tenured team member who works in a different part of the company and support the onboarding employee’s transition to Artsy.  Who listens, offers advice and helps new teammates feel comfortable in their new work environment.
+- There exist other conceptions of mentorship- an apprenticeship for example, or the more long-term relationship
+  between an experienced practitioner 'championing' a new developer as they enter the industry. This guide isn't
+  meant to replace or erase any other definition, and is strictly about mentorship 'at Artsy.'
+- Related to mentors but generally coming from a non-engineering role, at Artsy we offer each new team member a
+_spirit guide_— a tenured team member who works in a different part of the company and support the onboarding
+employee’s transition to Artsy. Who listens, offers advice and helps new teammates feel comfortable in their new
+work environment.
 <!-- - TODO: talk to Orta/Sarah/Joey about how we used to do it. -->
 
 #### Simple answers to common questions
-Some common (but certainly not stupid) questions that mentors are well-positioned to address
-- *Setup step `x` didn't work*
-  - Try to work through it together with them- then create an issue or PR a fix if possible
-- *What meetings are 'mandatory', 'encouraged' or just open to folks who are interested?* 
-  - Calendar invites and new notification grooming seems to be one of the trickiest parts of the onboarding process, especially through team sprint rotations, but it's important to make sure that each new hire feels fully included as soon as possible. Consider showing off your own processes (and helping make sure they are getting all the right invitations)
-- *When should I show up?*
-  - Use your judgement, but communicate your availability when working remotely via slack and the OOO calendar.
-- *How/should I take vacation?*
-  - Yes. Talk to your manager and make sure it is on the OOO calendar.
-- *How long until I am fully onboarded/up to speed?*
-  - Aside from the team sprint rotations we dont have a firm number for this. Keep in touch with each other and, work together to set longer-term goals- encouraging them to work with their manager as well.
-- Who should I talk to or where should I post in slack about `x`?
-  - Answer varies- when in doubt, ask your mentor. For lots of questions when getting started with a new technology our [tech learning document](/resources/tech-learning.md) is a great start!
 
+Some common (but certainly not stupid) questions that mentors are well-positioned to address
+
+- _Setup step `x` didn't work_
+  - Try to work through it together with them- then create an issue or PR a fix if possible
+- _What meetings are 'mandatory', 'encouraged' or just open to folks who are interested?_
+  - Calendar invites and new notification grooming seems to be one of the trickiest parts of the onboarding
+    process, especially through team sprint rotations, but it's important to make sure that each new hire feels
+    fully included as soon as possible. Consider showing off your own processes (and helping make sure they are
+    getting all the right invitations)
+- _When should I show up?_
+  - Use your judgement, but communicate your availability when working remotely via slack and the OOO calendar.
+- _How/should I take vacation?_
+  - Yes. Talk to your manager and make sure it is on the OOO calendar.
+- _How long until I am fully onboarded/up to speed?_
+  - Aside from the team sprint rotations we dont have a firm number for this. Keep in touch with each other and,
+    work together to set longer-term goals- encouraging them to work with their manager as well.
+- Who should I talk to or where should I post in slack about `x`?
+  - Answer varies- when in doubt, ask your mentor. For lots of questions when getting started with a new technology
+    our [tech learning document](/resources/tech-learning.md) is a great start!

--- a/onboarding/mentors.md
+++ b/onboarding/mentors.md
@@ -77,7 +77,7 @@ Get to know each other. This can be a nice, casual conversation. Focus on active
 
 - Check in to make sure your onboardee is moving forward in their checklist. Common stumbling areas include stale
   steps in the developer setup and getting invited to myriad organizations, lists and websites (slack, jira,
-  github, notion, heroku, aws+hokusai, zeplin, ...)
+  github, notion, heroku, aws, hokusai ...)
 - Look for chances to pair or work alongside one another throughout the week.
   - If their early work hasn't exposed them to `artsy/gravity`, consider pairing on something trivial or just
     setting it up, breaking and fixing a test.

--- a/onboarding/mentors.md
+++ b/onboarding/mentors.md
@@ -14,23 +14,22 @@ engineering community. Of course, no culture is static; rather than a one-time g
 to curate, maintain and protect. We recognize that all of these ideals require intentional work and iteration
 between people to make them reality. One way we work to maintain and grow this culture is through mentorship.
 
-Although mentorship can occur in many forms, currently on the Artsy engineering team our only formal mentorship
-program is for new hires. Although both the company and engineering team have programs that fall under the umbrella
-of _mentorship, career development_ and _education_, this doc will focus on mentorship in the context of onboarding
-to the engineering team.
+Mentorship and professional development occur in many forms and contexts, but this doc is focused on mentoring for
+new engineering hires.
 
 ## The Onboarding Mentor
 
-Each new engineering hire is assigned an _Onboarding mentor_ are by their manager. Onboarding mentors are not
-managers or teachers, but exist to help new engineers - _regardless of past experience_ - become confident,
-comfortable members of the team. An onboarding mentor acts as a new hire's perhaps most consistent peer (and
-**non-manager**) throughout the sprint rotation process. **As an onboarding mentor, you are expected to**
+Each new engineering hire is assigned an _Onboarding mentor_ by their manager. Onboarding mentors are not managers
+or teachers, but exist to help new engineers - _regardless of level_ - become confident, comfortable members of the
+team. An onboarding mentor acts as a new hire's perhaps most consistent peer (and **non-manager**) throughout the
+sprint rotation process. **As an onboarding mentor, you are expected to:**
 
 - Support and guide your mentee at least through the first 3 months. Expect that this will take a bit of your time,
   at least 4-8 hours per week.
 - Schedule at least one meeting per week to check in with your mentee
 - Be an available pair when your mentee gets stuck
-- Provide a safe space for sounding other questions and concerns (though _not_ as a replacement for People Ops)
+- Provide a safe space for sounding other questions and concerns (though _not_ as a replacement for People Ops or
+  the mentee's manager)
 - Be a source of consistency throughout their onboarding team sprint rotations
 
 ### How to be an onboarding mentor
@@ -41,25 +40,11 @@ ensure the relationship evolves over time to remain useful.
 
 #### What to do?
 
-1-2 meetings a week is not going to fill your time, and in a vacuum will probably not be a very productive use of
-your time. A menu of possible ideas for extracurriculars:
+Meeting 1:1 is one way to support them, but the overall goal is to _help them feel comfortable and productive on
+the team_. Keeping in mind that every new engineer brings their own package of skills and past experiences, here is
+one sample itinerary:
 
-- Help set up a new repository or language tooling
-- Attend an optional meeting together:
-  - office hours
-  - an engineering practice
-  - peer learning working group
-- Draft a blog post together
-- Update documentation
-- Take the opportunity to learn from your mentee about their current sprint rotation work - there's a good chance
-  you have no idea what that team is up to
-- Share and discuss an article from the world of technology
-- Just Hack
-
-#### A hypothetical onboarding mentor's agenda
-
-_TODO: Update for 2020_  
-**Your first day**
+**The first day**
 
 - Keep tabs on your mentee's schedule. Their first day will be full of paperwork and meetings with People Ops but
   some good tasks for a mentor:
@@ -72,7 +57,7 @@ _TODO: Update for 2020_
     - Their team lead
     - Artsy atlas, calendars, benefit websites, mail filters, Jira and Github management tools...
 
-**Your first meeting**
+**The first meeting**
 
 Get to know each other. This can be a nice, casual conversation. Focus on active listening.
 
@@ -84,11 +69,11 @@ Get to know each other. This can be a nice, casual conversation. Focus on active
 - Prior experience with our [technology stacks](/playbooks/technology-choices.md) (and others)
 - Other relevant past experience, particularly 'soft skills' that might seem orthogonal to writing code
 - Are they using the
-  [onboarding checklist](https://github.com/artsy/README/blob/master/.github/ISSUE_TEMPLATE/engineering-onboarding.md)?
+  [🔒 onboarding checklist](https://github.com/artsy/potential/blob/master/.github/ISSUE_TEMPLATE/engineering-onboarding.md)?
   If so, check in on where they are and offer to be a resource on things there. Some tasks might stand out as good
   things to do in between People Ops meetings, while working nearby each other or to pair on.
 
-**Your first week**
+**The first week**
 
 - Check in to make sure your onboardee is moving forward in their checklist. Common stumbling areas include stale
   steps in the developer setup and getting invited to myriad organizations, lists and websites (slack, jira,
@@ -97,23 +82,32 @@ Get to know each other. This can be a nice, casual conversation. Focus on active
   - If their early work hasn't exposed them to `artsy/gravity`, consider pairing on something trivial or just
     setting it up, breaking and fixing a test.
   - If they haven't set up hokusai yet, consider pairing on that.
-- Try to have another meeting towards the end of the week- **especially** if they are leaving New York. Revisit
-  things you talked about in the first meeting and look for areas that could have gone better. Consider amending
-  relevant documents like this one.
+- Try to have another meeting towards the end of the week. Revisit things you talked about in the first meeting and
+  check in to see how they are doing.
 
-**Your first year**
+**The first few months**
 
-- New hires usually begin with a sprint-by-sprint rotation through our teams, a whirlwind that can last upwards of
-  2 months. It's good to check in with your mentee during this time.
+- New hires usually begin with a sprint-by-sprint rotation through our teams, a process that can last upwards of 2
+  months.
+  - Check in with your mentee during this time and to help unblock them if necessary.
+  - Rotations tend to introduce new product areas and systems, and those are natural opportunities to provide a
+    code tour, product demo, or informal history/background.
+- Attend a meeting together:
+  - office hours
+  - an engineering practice
+  - peer learning working group
 - Consider reaching out to other mentors as well
 - Periodically check in with yourself on what you think you know about your mentee:
-  - How are they feeling at work? It's good to be aware (if you can) of comfort level, new technologies and more
-    dynamic pieces of how they are getting situated at Artsy.
+  - How are they feeling at work? It's good to be aware (if you can) of comfort level, new technologies and how
+    they are getting situated at Artsy.
   - Are there any opportunities to pair together (or for them to pair with someone else) on a new technology or
     domain area?
-- Many mentoring pairs continue scheduling semi-weekly coffee chats in the weeks and months going forward. As the
-  relationship becomes less formal these can be great to keep in touch with a team member you have a special
-  relationship with!
+- When the mentee joins their first full-time team, check in with them through the first few sprints. How is their
+  ramp-up going? Are they feeling productive and safe within the team? Encourage the mentee to bring up these
+  topics with their manager if you think it would help.
+- Many mentoring pairs continue scheduling semi-weekly coffee chats in the weeks and months going forward. Share
+  and discuss relevant articles or collaborate on a blog post; As the relationship becomes less formal these can be
+  great to keep in touch with a team member you have a special relationship with!
 
 ## Footnotes
 
@@ -121,16 +115,10 @@ Get to know each other. This can be a nice, casual conversation. Focus on active
 
 - [Blog post on professional development at Artsy](http://artsy.github.io/blog/2016/09/22/professional-development-at-artsy-engineering/)
 - [Onboarding Home](/onboarding)
-- There exist other conceptions of mentorship- an apprenticeship for example, or the more long-term relationship
-  between an experienced practitioner 'championing' a new developer as they enter the industry. This guide isn't
-  meant to replace or erase any other definition, and is strictly about mentorship 'at Artsy.'
-- Related to mentors but generally coming from a non-engineering role, at Artsy we offer each new team member a
-_spirit guide_— a tenured team member who works in a different part of the company and support the onboarding
-employee’s transition to Artsy. Who listens, offers advice and helps new teammates feel comfortable in their new
-work environment.
-<!-- - TODO: talk to Orta/Sarah/Joey about how we used to do it. -->
+- [🔒 Artsy's Mentorship Program](https://www.notion.so/artsy/Mentorship-Program-014ba1ab5a0044d6ac0de0242c7779a4)
+  as part of the Inclusion Working Group
 
-#### Simple answers to common questions
+### Simple answers to common questions
 
 Some common (but certainly not stupid) questions that mentors are well-positioned to address
 


### PR DESCRIPTION
This PR simplifies our mentorship doc to outline a single kind of engineering mentor- the 'onboarding mentor' role. I think it would be good to get feedback from others on the team, including anyone planning to start as an onboarding mentor or upcoming hires.

I think we should still radically trim or remove the 'hypothetical agenda' section in favor of a shorter menu of possible activities.

No significant changes from 'your first week' down - this is just prettier formatting text by # of columns.