### PR TITLE
RFC: Add sections explicitly outlining RFC implementation and approval to the RFC template and documentation

### DIFF
--- a/playbooks/rfcs.md
+++ b/playbooks/rfcs.md
@@ -43,19 +43,14 @@ Create a plan for how the RFC will be implemented. If the change is complex or l
 feedback process to iterate on the proposal as you implement and creating milestones and/or metrics to track
 progress.
 
-Decide who needs to know about this proposal, what role teammates will play in the process and how the RFC will be
-considered approved.
+Decide how you'll resolve the RFC:
 
-- What is the scope of the proposal? Does the whole engineering team need to know or just a smaller group of
-  engineers?
-- Who should actively approve of this RFC? Who should give feedback?
-- Does the change make sense without further discussion from engineering leadership?
-
-Here are some examples of how an RFC could be resolved:
-
-- X% of the engineering team actively approves this change.
-- The point people of the impacted repos approve this change.
-- Engineering leadership approves the changes after collecting feedback from the team.
+- Specify whose feedback is necessary on this RFC with review requests.
+- Specify for how long feedback will be collected and incorporated into the proposal. At least a week for feedback
+  is appropriate for any proposal impacting all of engineering.
+- Specify how approval will ultimately be decided. Does this depend on X% of the engineering team actively
+  approving, point people of certain repos, or perhaps engineering leadership? If specific people need to approve
+  use an `@` mention in the RFC to say so.
 
 Create an issue, and work from this template:
 
@@ -64,6 +59,11 @@ Create an issue, and work from this template:
     ## Proposal:
 
     Apply a spell checker to every markdown document that appears in a PR.
+
+    As a trial, we'll add a new Peril rule that implements spellchecking on every PR that includes
+    a Markdown document in README. We'll then gather asynchronous feedback from engineers about the
+    new Peril rule and how it impacted their workflow. We'll confirm we want this rule and incorporate
+    any further changes to the original RFC. We'll then roll out the Peril rule to all systems.
 
     ## Reasoning
 
@@ -83,16 +83,11 @@ Create an issue, and work from this template:
 
     You can see our discussion [in slack here](/link/to/slack.com)
 
-    ## How this RFC is implemented
-
-    As a trial, we'll add a new Peril rule that implements spellchecking on every PR that includes
-    a Markdown document in README. We'll then gather asynchronous feedback from engineers about the
-    new Peril rule and how it impacted their workflow. We'll confirm we want this rule and incorporate
-    any further changes to the original RFC. We'll then roll out the Peril rule to all systems.
-
     ## How this RFC is resolved
 
-    This RFC will be considered approved when 50% of the engineers at Artsy actively approve this proposal.
+    We'll collect feedback on this RFC from the team for a week. We'll consider this RFC approved
+    if 50% of the engineering team actively approves of this change. Add a 👍 or 👎  reaction to
+    this proposal to vote.
 
 Give a week for discussion.
 
@@ -124,10 +119,6 @@ If possible, please use one of these for the Level of Support section:
 - `5: Unclear Resolution.`
 - `6: RFC Rejected.`
 - `7: RFC Rejected, with Conflicting Feedback.`
-
-Resolving an RFC requires you to have some nuance about the feedback. If it seems to be unresolved, or still active
-a week later, then calling a town hall style meeting for people involved will probably shake out some kind of
-resolution.
 
 [potential]: https://github.com/artsy/potential/
 [mobile]: https://github.com/artsy/mobile

--- a/playbooks/rfcs.md
+++ b/playbooks/rfcs.md
@@ -48,9 +48,11 @@ Decide how you'll resolve the RFC:
 - Specify whose feedback is necessary on this RFC with review requests.
 - Specify for how long feedback will be collected and incorporated into the proposal. At least a week for feedback
   is appropriate for any proposal impacting all of engineering.
-- Specify how approval will ultimately be decided. Does this depend on X% of the engineering team actively
-  approving, point people of certain repos, or perhaps engineering leadership? If specific people need to approve
-  use an `@` mention in the RFC to say so.
+- Specify how approval will ultimately be decided. By default most proposals can be considered approved if there is
+  no objection. However, if the change is complex or has wide impact you may want a more structured approval
+  process. For example, does this depend on X% of the engineering team actively approving, point people of certain
+  repos, or perhaps engineering leadership? If specific people need to approve use an `@` mention in the RFC to say
+  so.
 
 Create an issue, and work from this template:
 

--- a/playbooks/rfcs.md
+++ b/playbooks/rfcs.md
@@ -39,6 +39,24 @@ Find the right repo:
 - Does it affect the whole dev team? (use [README](https://github.com/artsy/README))
 - Can't figure it out or needs to be private? (use [Potential][] as a fallback)
 
+Create a plan for how the RFC will be implemented. If the change is complex or large in scope consider defining a
+feedback process to iterate on the proposal as you implement and creating milestones and/or metrics to track
+progress.
+
+Decide who needs to know about this proposal, what role teammates will play in the process and how the RFC will be
+considered approved.
+
+- What is the scope of the proposal? Does the whole engineering team need to know or just a smaller group of
+  engineers?
+- Who should actively approve of this RFC? Who should give feedback?
+- Does the change make sense without further discussion from engineering leadership?
+
+Here are some examples of how an RFC could be resolved:
+
+- X% of the engineering team actively approves this change.
+- The point people of the impacted repos approve this change.
+- Engineering leadership approves the changes after collecting feedback from the team.
+
 Create an issue, and work from this template:
 
     Title: "RFC: Add a Markdown Spell Checker to all Markdown docs in PR"
@@ -65,14 +83,25 @@ Create an issue, and work from this template:
 
     You can see our discussion [in slack here](/link/to/slack.com)
 
-Give a week.
+    ## How this RFC is implemented
+
+    As a trial, we'll add a new Peril rule that implements spellchecking on every PR that includes
+    a Markdown document in README. We'll then gather asynchronous feedback from engineers about the
+    new Peril rule and how it impacted their workflow. We'll confirm we want this rule and incorporate
+    any further changes to the original RFC. We'll then roll out the Peril rule to all systems.
+
+    ## How this RFC is resolved
+
+    This RFC will be considered approved when 50% of the engineers at Artsy actively approve this proposal.
+
+Give a week for discussion.
 
 ### Resolution
 
-Resolve the RFC, you can work with this template:
+To resolve the RFC you can work with this template:
 
     ## Resolution
-    We decided to do it.
+    We decided to do it. 50% of the engineering team actively approved of this change.
 
     ## Level of Support
     3: Majority acceptance, with conflicting feedback.


### PR DESCRIPTION
## Proposal

Update the RFC docs and templates to include an explicit section on ~(1) how an RFC will be implemented and (2)~ how an RFC is resolved. This section should be a precise description of how we'll know when the proposal has been accepted.

## Reasoning

The goal of this RFC is to drive more clarity about the implementation and resolution of RFCs. Clearer guidelines around implementation and resolution will allow team members (especially newer members) to contribute more easily to the RFC process.

~While in practice we do include implementation plans for RFCs adding this section to the template makes it explicit and serves as a reminder to think about how to roll out the proposal. This is especially important for changes that have large scope and might require broader feedback and alignment to fully implement.~

Our current RFC resolution process is fuzzy and does not address complex changes well. To help teammates all be on the same page and to create alignment around change more easily, we should be explicit about how an RFC will be considered approved when we create an RFC. If _how_ to approve a given RFC creates some conflict, that's good! That means we'll have a chance as a team to work out issues and create stronger consensus for a proposal.

## Exceptions

We should strive for impact over perfection. RFC creators should use their best judgment about how to use these sections. If the change is minor then it might not require a detailed implementation or resolution section.

## How this RFC is implemented

This RFC updates the RFC template and docs and will be implemented as soon as this PR is merged.

## How this RFC is resolved

This RFC will be considered approved if (1) @sweir27 and @joeyAghion explicitly approve as primary stakeholders for the RFC process and (2) if the level of support from the engineering team at large is at least `Majority acceptance, with conflicting feedback.` However, open to other ways to consider this RFC "approved" and think it makes for a good discussion!
 