### PR TITLE
fix: update documentation for resolving an incident

### DIFF
--- a/playbooks/support/responding.md
+++ b/playbooks/support/responding.md
@@ -141,7 +141,7 @@ follow-up items are tracked and the OpsGenie incident clearly reflects this stat
    - Mark the incident as **RESOLVED**
 
 3. Resolve any outstanding incidents on our status page via statuspage.io.
-4. If the incident was Critical, create a post mortem in OpsGenie.
+4. Create a post mortem in OpsGenie.
 5. Update relevant [playbooks](https://github.com/artsy/potential/wiki) 🔒 with any lessons.
 
 ## Severity of Incidents


### PR DESCRIPTION
This PR updates our documentation for responding to incidents so that engineers are instructed to write postmortems for all incidents, regardless of severity.
