### PR TITLE
feat: run standup reminder via @artsy/cli every Monday at 9am ET

### DIFF
--- a/.github/workflows/mondayInformationals.yml
+++ b/.github/workflows/mondayInformationals.yml
@@ -16,6 +16,7 @@ jobs:
           echo "::set-output name=standup::$(artsy scheduled:standup-reminder)"
           echo "::set-output name=rfcs::$(artsy scheduled:rfcs)"
         env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
           SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
       - name: Standup Reminder > Slack

--- a/.github/workflows/mondayInformationals.yml
+++ b/.github/workflows/mondayInformationals.yml
@@ -1,7 +1,7 @@
 name: "Monday Informationals"
 on:
   schedule:
-    - cron: "0 14 * * MON"
+    - cron: "15 1 * * MON"
 
 jobs:
   monday_informationals:

--- a/.github/workflows/mondayInformationals.yml
+++ b/.github/workflows/mondayInformationals.yml
@@ -1,0 +1,36 @@
+name: "Monday Informationals"
+on:
+  schedule:
+    - cron: "0 14 * * MON"
+
+jobs:
+  monday_informationals:
+    name: Monday Informationals
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Dependencies
+        run: yarn global add --silent @artsy/cli@alpha
+      - name: Run CLI
+        id: cli
+        run: |
+          echo "::set-output name=standup::$(artsy scheduled:standup-reminder)"
+          echo "::set-output name=rfcs::$(artsy scheduled:rfcs)"
+        env:
+          OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
+          SLACK_WEB_API_TOKEN: ${{ secrets.SLACK_WEB_API_TOKEN }}
+      - name: Standup Reminder > Slack
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          custom_payload: |
+            ${{steps.cli.outputs.standup}}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Open RFCs > Slack
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          custom_payload: |
+            ${{steps.cli.outputs.rfcs}}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Use the Artsy CLI and scheduled GitHub actions for our Monday Informationals.

Currently in-progress. This doesn't support all of the Peril-backed tasks yet.

- [ ] Closed Source Rationale Check
- [ ] Compare Schemas
- [x] Standup Reminder
- [x] Weekly RFC Summary

#FF #FutureFriday

**Example**

<img width="680" alt="Screen Shot 2021-02-07 at 3 33 17 PM" src="https://user-images.githubusercontent.com/123595/107158695-dadf3880-6959-11eb-8a1e-9d4f2cfca8e1.png">
