### PR TITLE
RFC: Propose conventions for project set-up and configuration

### DIFF
--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -25,6 +25,7 @@ practice should be incorporated, submit a PR!
 | [Data Migrations](/playbooks/data-migrations.md#readme) | Preparing, reviewing and executing data migrations |
 | [Dependency Management Recommendations](/playbooks/dependencies.md#readme) | How do we want to handle new dependencies to our apps? |
 | [Deployments](/playbooks/deployments.md#readme) | How systems are deployed at Artsy |
+| [Development environments](/playbooks/development-environments.md#readme) | Getting set up to work on new projects |
 | [Documentation](/playbooks/documentation.md#readme) | How and where to document or share content |
 | [Engineer workflow](/playbooks/engineer-workflow.md#readme) | How we work together |
 | [Extracting Services](/playbooks/extracting-services.md#readme) | When and why to consider extracting or decoupling systems |

--- a/playbooks/development-environments.md
+++ b/playbooks/development-environments.md
@@ -1,0 +1,96 @@
+---
+title: Development environments
+description: Getting set up to work on new projects
+---
+
+# Development environments
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Goals](#goals)
+- [Prerequisites](#prerequisites)
+- [Project set-up](#project-set-up)
+- [Shared configuration](#shared-configuration)
+- [Examples](#examples)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Goals
+
+- New working environments are set up quickly, easily, and consistently (ideally with a single command).
+- Team- or project-wide configuration changes are rolled out without needing a lot of communication and
+  coordination.
+- Projects adopting favored technologies leverage common, simple set-up.
+- Developers using common tools (mac, bash, homebrew, nvm...) get productive without any special set-up.
+- Developers choosing less common tools are still productive, if necessary using the basic set-up as a guide.
+- Projects default to configuration values that are appropriate for development (just as they run in "development"
+  mode by default).
+- Both local and containerized development are supported, with minimal duplication.
+- Sensitive values are never committed to repositories, whether open- or closed-source.
+- Other things being equal, less configuration, simpler-setup, and fewer dependencies are better than more.
+
+## Prerequisites
+
+Setup tooling is optimized for a default set of tools:
+
+- Mac computers
+- `bash` shell
+- [Homebrew](https://brew.sh/) for installing and managing supporting services
+- Docker for containerization
+- [nvm](https://github.com/nvm-sh/nvm) for managing node versions
+- [rbenv](https://github.com/rbenv/rbenv) for managing ruby versions
+- [hokusai](hokusai.md) for managing deployed applications
+- [VSCode](https://code.visualstudio.com/) for text editing
+- [awscli](https://aws.amazon.com/cli/) for AWS operations
+
+Developers who find other tools compelling may need to adapt setup procedures to their choices. For the sake of
+simplicity, we avoid making setup tooling heavily conditional on local choices.
+
+The [shared setup script](https://github.com/artsy/potential/blob/master/scripts/setup)🔒 installs these tools, and
+individual projects' setups may depend on them.
+
+These choices can and should be improved (by [RFC-style](rfcs.md) pull request), but care should be taken to update
+any dependent projects.
+
+## Project set-up
+
+Project's READMEs should clearly document the commands necessary for fresh set-up, ideally just reviewing and
+running a `./bin/setup` script (or whatever is idiomatic for that stack). The script should:
+
+- install dependencies such as data stores
+- install necessary language runtimes/versions
+- initialize configuration with values that are appropriate for development (ideally none)
+- install packages (rubygems, node modules, etc.)
+- create and seed databases, if appropriate
+- ideally be idempotent (i.e., re-running setup should work to update an existing environment)
+- be clearly organized and commented, so it can serve as a guide in incompatible environments
+
+## Shared configuration
+
+We strive to avoid committing any sensitive values to repositories, but sometimes they are necessary for local
+development. By convention, projects load configuration values from both:
+
+- a `.env.shared` file with common configuration values, and
+- a `.env` file with any developer-specific overrides (or empty)
+
+These files are excluded from source-control. The setup command initializes them, updating `.env.shared` from a
+private S3 location.
+
+Local ruby development depends on the [`foreman`](https://github.com/ddollar/foreman) utility and a `.foreman` file
+([e.g.](https://github.com/artsy/horizon/blob/master/.foreman)) to respect these files. Local node.js development
+depends on [node-foreman](https://github.com/strongloop/node-foreman) and the `--env` argument
+([e.g.](https://github.com/artsy/metaphysics/blob/edad4a5f2215a61bb09719901a4fdfd38cd0afcd/package.json#L19)).
+
+Docker-based development respects these files by listing both in docker's `env_file` property
+([e.g.](https://github.com/artsy/horizon/blob/2202391c9622b5ec655bf2c6d0f35ef379d0687f/hokusai/development.yml#L18-L20)).
+
+To _update_ shared configuration values, simply modify `.env.shared` and re-upload it to its shared location as
+`.env.<project>`. E.g.:
+
+    aws s3 cp .env.shared s3://artsy-citadel/dev/.env.zulu
+
+## Examples
+
+- [Gravity's `script/setup`](https://github.com/artsy/gravity/blob/master/script/setup)🔒
+- [Metaphysics' `scripts/setup.sh`](https://github.com/artsy/metaphysics/blob/master/scripts/setup.sh)


### PR DESCRIPTION
This documents a convention for set-up and configuration that we've been trying to refine over several iterations in [Horizon](https://github.com/artsy/horizon/pull/177), Gravity ([1](https://github.com/artsy/gravity/pull/13345), [2](https://github.com/artsy/gravity/pull/13372)), [Volt](https://github.com/artsy/volt/pull/4582), and [Metaphysics](https://github.com/artsy/metaphysics/pull/2765).

The _aspiration_ is that setting up a new development environment is turn-key, and there's a shared, up-to-date place to put any configuration necessary for development.

### For debate:

**Whether to automate setup at all.** There's been a lot of discussion recently about whether project setup should be standardized and automatic or tailored and manual. Long term, containerized environments should solve this, but I tried to find a balance by suggesting:
* we establish default set-up scripts for the most common environment
* the setup be in-line documented, to serve as a guide in less common circumstances

**What "most common" environment to target.** Version manager and shell preferences vary widely, but we need to start somewhere. I took as defaults the tools currently supported by the shared setup script and working examples in projects. Ultimately I'm not attached to any of these, as long as there's always an "easy," default path.
