### PR TITLE
feat: update monday informationals to use @artsy/cli stable version

### DIFF
--- a/.github/workflows/monday-informationals.yml
+++ b/.github/workflows/monday-informationals.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: '12'
 
       - name: Install Dependencies
-        run: npm install --global @artsy/cli@alpha
+        run: npm install --global @artsy/cli
 
       - name: Run CLI
         id: cli


### PR DESCRIPTION
This workflow was pinned to the alpha NPM tag while https://github.com/artsy/artsy-cli/pull/24 was still open.

We can use the stable channel now.