### PR TITLE
docs: Add playbook on practices

### DIFF
--- a/practices/README.md
+++ b/practices/README.md
@@ -9,6 +9,8 @@ prioritization, visibility, and capacity purposes). The
 [project list](https://www.notion.so/artsy/17c4b550458a4cb8bcbf1b68060d63e6?v=2b874803f96c483bbdc2e80b7fbd25f9)🔒
 is useful for deciding how to organize and divide large efforts up among product teams.
 
+See [the Practice Playbook](/practices/playbook.md#readme) for tips on running a practice.
+
 <!-- prettier-ignore-start -->
 <!-- start_toc -->
 | Doc | Overview |


### PR DESCRIPTION
Oops, this link got removed with `scripts/create-readmes.ts`, add link outside of TOC autoformatted table.