### PR TITLE
Update playbook path in practices readme

### DIFF
--- a/practices/README.md
+++ b/practices/README.md
@@ -9,7 +9,7 @@ prioritization, visibility, and capacity purposes). The
 [project list](https://www.notion.so/artsy/17c4b550458a4cb8bcbf1b68060d63e6?v=2b874803f96c483bbdc2e80b7fbd25f9)🔒
 is useful for deciding how to organize and divide large efforts up among product teams.
 
-See [the Practice Playbook](/practices/playbook.md#readme) for tips on running a practice.
+See [the Practice Playbook](/playbooks/practices.md) for tips on running a practice.
 
 <!-- prettier-ignore-start -->
 <!-- start_toc -->


### PR DESCRIPTION
The current link to "_the Practice Playbook_" is returning a [404](https://github.com/artsy/README/blob/master/practices/playbook.md#readme). This updates the path to point to the [correct location](https://github.com/artsy/README/blob/master/playbooks/practices.md).