### PR TITLE
Add a prompt for new podcast episodes

### DIFF
--- a/events/open-standup.md
+++ b/events/open-standup.md
@@ -78,7 +78,7 @@ _Open RFCs (see #dev for list 9am EST on Mondays) or technical plans under consi
 
 -
 
-_New Milestones / Repos / Blog Posts / New features or updated functionality released: prompt Auction, Gallery,
+_New Milestones / Repos / Blog Posts / Podcast Episodes / New features or updated functionality released: prompt Auction, Gallery,
 Platform, Grow, Purchase teams_
 
 -


### PR DESCRIPTION
Noticed while running today's standup that we could benefit from a prompt for new episodes, esp. since we've been so prolific lately.