### PR TITLE
docs: Add Why's Poignant Guide to Ruby

### DIFF
--- a/resources/tech-learning.md
+++ b/resources/tech-learning.md
@@ -135,7 +135,7 @@ _See also [JavaScript](#javascript-+-nodejs) & [Swift + Objective C](#swift-+-ob
 [es6]: https://medium.com/sons-of-javascript/javascript-an-introduction-to-es6-1819d0d89a0f
 [dinos]: https://medium.com/the-node-js-collection/modern-javascript-explained-for-dinosaurs-f695e9747b70
 [rdoc]: https://ruby-doc.org/core-2.5.1/
-[poignant_guide]: https://poignant.guide/
+[poignant_guide]: https://poignant.guide/book/chapter-3.html
 [scala_exercises]: https://www.scala-exercises.org/
 [ramping_scala]: https://www.thoughtworks.com/talks/scala-the-good-parts-how-to-ramp-up-a-team-in-scala
 [effective_scala]: https://twitter.github.io/effectivescala


### PR DESCRIPTION
I still think Why's Guide is an excellent tool for communicating a lot
of context regarding the Ruby community and *mentality*. There are a
number of incredibly helpful (and entirely absurd) examples from _why
that taught me a lot about the flexibility and expressiveness of Ruby as
a programming language.

Plus, I think the guide qualifies as art and this is Artsy.