### PR TITLE
docs: Adding the postcards channel to the slack list of other topics

### DIFF
--- a/culture/slack.md
+++ b/culture/slack.md
@@ -91,6 +91,7 @@ want to check out:
   jam-sessions
 - [#productivity-tips](https://artsy.slack.com/messages/productivity-tips) 🔒 for random things that make you more
   productive
+- [#postcards](https://artsy.slack.com/messages/postcards) 🔒 for the love of postcards
 
 ### Tips and Tricks
 


### PR DESCRIPTION
Small PR to add the postcards channel to the slack list of other topics channels