### PR TITLE
doc: update incident review resolution steps

### DIFF
--- a/playbooks/support/responding.md
+++ b/playbooks/support/responding.md
@@ -157,7 +157,7 @@ follow-up items are tracked and the OpsGenie incident clearly reflects this stat
     > Aim to complete the analysis within 2 days.
 5. Add a new row to the [Incident Review Schedule](https://www.notion.so/artsy/852e6a28fcda46ada5596f6190c9e006?v=210da6a9fe314893babbd81220b0523e)
  with links to the _incident_, the _postmortem_, the _date of the incident_ and a brief _summary_.
-6. Update relevant [playbooks](https://github.com/artsy/potential/wiki) 🔒 with any lessons.
+6. Update relevant [playbooks](https://www.notion.so/Engineering-Playbooks-b655fe54c1ce4b35af342c9ed9a489ae) 🔒 with any lessons.
 
 ## Severity of Incidents
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-3671

This PR expands the incident resolution steps and clarifies that a _postmortem_ draft should be generated within 2 days time.

The added step asks the responder(s) to create an entry in the [Incident Review Schedule](https://www.notion.so/artsy/852e6a28fcda46ada5596f6190c9e006?v=210da6a9fe314893babbd81220b0523e) db with links to the incident, the postmortem, the date of the incident and a brief summary. The motivation for this change is to help streamline IR meeting preparation and scheduling.

[Relevant notion page](https://www.notion.so/artsy/Incident-Review-Facilitation-a1355615adc24026a5ddc49fff2b6761)