### PR TITLE
RFC: Adopt Swift for new native feature work over Objective-C

### DIFF
--- a/playbooks/technology_radar/artsy-tech-radar.csv
+++ b/playbooks/technology_radar/artsy-tech-radar.csv
@@ -1,7 +1,7 @@
 name,ring,quadrant,isNew,description
 GraphQL,adopt,languages & frameworks,TRUE,"Appreciated for its flexibility and efficiency for clients."
 JSON,adopt,languages & frameworks,FALSE,"We prefer JSON over most other data formats for its self-describing properties."
-Objective-C,adopt,languages & frameworks,FALSE,"We generally opt for React Native, but when necessary for quality or usability, we will build native features in Objective-C using UIKit. Core Eigen infrastructure and React Native itself is written in Objective-C."
+Objective-C,hold,languages & frameworks,FALSE,"Because we use React Native some amount of Objective-C bridging code will remain necessary, these should be thin layers to swift features. Some legacy core Eigen infrastructure and React Native itself is written in Objective-C."
 Rails,adopt,languages & frameworks,FALSE,
 React Native,adopt,languages & frameworks,FALSE,"New iOS work should use React Native. See also Objective-C."
 React.js,adopt,languages & frameworks,FALSE,
@@ -46,7 +46,7 @@ HashiCorp Vault,assess,tools,TRUE,
 Helm,assess,tools,TRUE,
 Coffeescript,hold,languages & frameworks,FALSE,
 Scala,hold,languages & frameworks,FALSE,
-Swift,hold,languages & frameworks,FALSE,
+Swift,adopt,languages & frameworks,FALSE,"We generally opt for React Native, but when necessary for quality, usability or features tightly integrated with OS, we will build native features in Swift using UIKit. see Objective-C."
 AWS Lambda,hold,platforms,TRUE,
 Google cloud,hold,platforms,FALSE,
 Heroku,hold,platforms,FALSE,"We prefer kubernetes where we have shared solutions for authorization, logging, monitoring, alerting, scaling, and routing."


### PR DESCRIPTION
# Proposal:
Adopt Swift over Objective-C for the fairly narrow but important use case of native features that cannot be written in react native or cannot be written in react-native without compromising user experience.

**Major caveat:** we should still prefer react-native whenever possible. 

# Reasoning:

##  Reasons for preferring swift for native iOS feature development over Objective-C:
- Swift is what Apple's docs, development and guidelines prefer
   - in general the iOS communities knowledge base has largely moved to Swift
- Swift is more beginner friendly and familiar for devs coming from modern languages
   - more familiar syntax than SmallTalk based Objective-C with message passing
- Swift code has less boilerplate
- Modern language features are rolling out to Swift 
    - https://docs.swift.org/swift-book/LanguageGuide/Concurrency.html
- Swift is type safe and null safe and fits with our general adoption of types in typescript
- Swift has surpassed Objective-C by quite a bit in general popularity
      https://www.tiobe.com/tiobe-index/
      https://web.archive.org/web/20161102072439/https://www.tiobe.com/tiobe-index/

## Reasons in the past for not adopting Swift over Objective-C:
- Swift is young and version updates break things 
  - Swift  is now 7 years old
  - Swift reached ABI and module stability with version 5 and is much more stable
- Swift compilation is slow
   - this situation has greatly improved over the years but can remain a pain point but is mostly true for large codebases of Swift code, with react-native as our main tool for new features the risk of this being a problem is pretty small because A) we will not have a huge amount of Swift code B) react-native and hot reloading limits how often devs have to rebuild native code

# Additional Context and Considerations:

##  Retro of Swift at Artsy in 2017:
https://artsy.github.io/blog/2017/02/05/Retrospective-Swift-at-Artsy/
- this was mostly about preferring react-native over Swift for new feature development, which should remain our first choice
- some of the other objections addressed above

## Objective-C isn't dead!:
I am not proposing rewriting existing features now written in Objective-C that work to Swift. Simply that we prefer Swift when possible for new native features. Gradually if we find it beneficial or need to refactor old components we can adopt Swift then. 

React native bridging code is recommended by the docs to be in Objective-C, we should stick with what the docs suggest here but this should generally be a fairly thin layer of functions exposed to react-native and any major functionality can be called via these functions in Swift code. 

## Mobile stack preference in order should this RFC be accepted:

@pvinis put succinctly below
1. React Native whenever possible, e.g the vast majority of mobile feature work should be react native
2. Swift when we need to write native features or react-native doesn't support the UX we want
3. Objective-C for glue code like bridging between react-native and native code 

## Why not Assess then Adopt?

Swift is already in use by many companies in production, in fact we are already using it in production for Live Auctions, Folio and soon the Artsy Widget, so this is more to get alignment with how we think about preferences than to assess if Swift is production ready. 
  
# How this RFC is resolved:

I'll collect feedback on this RFC from the team for a week, interested especially in hearing from anyone who works in Eigen regularly or would like to. We'll consider this RFC approved if 50% of the engineering team actively approves of this change or there are no major objections that require. Add a 👍 or 👎  reaction to this proposal to vote.