### PR TITLE
docs: Add lattice to list of repos that master was renamed

### DIFF
--- a/playbooks/rename-master-to-main.md
+++ b/playbooks/rename-master-to-main.md
@@ -31,6 +31,7 @@ services and therefor could easily be changing the main branch name to 'main':
 - [homebrew-formulas](https://github.com/artsy/homebrew-formulas)
 - [artsy-hokusai-templates](https://github.com/artsy/artsy-hokusai-templates)
 - [orbs](https://github.com/artsy/orbs)
+- [lattice](https://github.com/artsy/lattice) ✅
 
 A list of artsy gems and libraries that might be loaded into gemfiles with referring to the master branch.
 


### PR DESCRIPTION
# Description

Adds [lattice](https://github.com/artsy/lattice) to list of repos that master was renamed to main