### PR TITLE
Propose Unleash trial (for feature-flagging and split-testing) more formally via radar

### DIFF
--- a/onboarding/README.md
+++ b/onboarding/README.md
@@ -15,6 +15,7 @@ More onboarding resources:
 <!-- start_toc -->
 | Doc | Overview |
 |--|--|
+| [Engineering Team Introduction](/onboarding/engineering-introduction.md#readme) | A brief introduction |
 | [Onboarding Responsibilities for Managers of New Hires](/onboarding/managers.md#readme) | Things for managers to remember during the early days of onboarding |
 | [Onboarding Responsibilities for Mentors of New Hires](/onboarding/mentors.md#readme) | How to be an effective mentor of a new hire |
 | [Onboarding for New Hires](/onboarding/new-hires.md#readme) | Your first steps to being productive |

--- a/playbooks/technology-choices.md
+++ b/playbooks/technology-choices.md
@@ -29,7 +29,7 @@ adopting, and retiring technologies:
   take every opportunity to retire or migrate away.
 
 Artsy's current choices can be [edited in raw form here](/playbooks/technology_radar/artsy-tech-radar.csv) and
-[viewed in radar format here](https://radar.thoughtworks.com/?sheetId=https%3A%2F%2Fraw.githubusercontent.com%2Fartsy%2Freadme%2Fmaster%2Fplaybooks%2Ftechnology_radar%2Fartsy-tech-radar.csv).
+[viewed in radar format here](https://radar.thoughtworks.com/?sheetId=https%3A%2F%2Fraw.githubusercontent.com%2Fartsy%2Freadme%2Fmain%2Fplaybooks%2Ftechnology_radar%2Fartsy-tech-radar.csv).
 
 ## Technical Plans and Review
 

--- a/playbooks/technology_radar/artsy-tech-radar.csv
+++ b/playbooks/technology_radar/artsy-tech-radar.csv
@@ -65,4 +65,5 @@ MongoDB,hold,tools,FALSE,
 Pingdom,hold,tools,TRUE,
 Semaphore,hold,tools,FALSE,
 SiteFeatures (Gravity),hold,tools,TRUE,"Site Features were used to turn on or off core functionality, but are easily replaced by Unleash (for platform-wide toggles) or Flipper (for Gravity-only settings)."
+Split.io,hold,tools,TRUE,"After a trial in the mobile app, we decided not to adopt this split-testing tool broadly (mostly due to cost)"
 Travis CI,hold,tools,TRUE,

--- a/playbooks/technology_radar/artsy-tech-radar.csv
+++ b/playbooks/technology_radar/artsy-tech-radar.csv
@@ -1,7 +1,6 @@
 name,ring,quadrant,isNew,description
 GraphQL,adopt,languages & frameworks,TRUE,"Appreciated for its flexibility and efficiency for clients."
 JSON,adopt,languages & frameworks,FALSE,"We prefer JSON over most other data formats for its self-describing properties."
-Objective-C,hold,languages & frameworks,FALSE,"Because we use React Native some amount of Objective-C bridging code will remain necessary, these should be thin layers to swift features. Some legacy core Eigen infrastructure and React Native itself is written in Objective-C."
 Rails,adopt,languages & frameworks,FALSE,
 React Native,adopt,languages & frameworks,FALSE,"New iOS work should use React Native. See also Objective-C."
 React.js,adopt,languages & frameworks,FALSE,
@@ -10,6 +9,7 @@ Ruby,adopt,languages & frameworks,FALSE,
 Spark,adopt,languages & frameworks,FALSE,"Artsy manages a Spark cluster and patterns exist to load data from the main Gravity database as well as other systems, distribute processing among all of the available nodes, and interact with S3, HDFS, or Redshift. See the Cinder repo."
 SQL,adopt,languages & frameworks,FALSE,
 styled-components,adopt,languages & frameworks,FALSE,
+Swift,adopt,languages & frameworks,FALSE,"We generally opt for React Native, but when necessary for quality, usability or features tightly integrated with OS, we will build native features in Swift using UIKit. see Objective-C."
 Typescript,adopt,languages & frameworks,FALSE,
 UIKit,adopt,languages & frameworks,FALSE,"See Objective-C."
 AWS,adopt,platforms,FALSE,
@@ -20,6 +20,7 @@ Redis,adopt,platforms,FALSE,
 Metaphysics' v2 schema,adopt,techniques,TRUE,"Consumers should switch to v2 rather than make further modifications to v1."
 Opaque identifiers,adopt,techniques,FALSE,"Friendly identifiers or 'slugs' are fine for URLs but opaque, permanent identifiers are preferred for all internal or programmatic uses."
 Responsive web pages,adopt,techniques,FALSE,"Rather than mobile- or desktop-specific designs, we prefer pages to degrade gracefully."
+Split testing,adopt,techniques,TRUE,"When scale permits (such as around high-volume product surfaces or early funnel steps), we prefer to make data-driven product decisions by evaluating user experiences in parallel through A/B- or A/B/*-style tests"
 Babel,adopt,tools,TRUE,"This is the description. You can use basic html such as the <strong>strong tag to emphasise keywords and phrases</strong> and insert <a href=""https://www.thoughtworks.com"">anchor links to documentation and referance material</a>."
 CircleCI,adopt,tools,FALSE,"for continuous integration over other services like Travis or Semaphore. Shared orbs and contexts help our projects apply best practices."
 Cloudflare,adopt,tools,TRUE,
@@ -35,6 +36,7 @@ Webpack,adopt,tools,FALSE,
 Elixir,trial,languages & frameworks,TRUE,
 Phoenix,trial,languages & frameworks,TRUE,
 OpsGenie,trial,tools,TRUE,
+Unleash,trial,tools,TRUE,"Unleash offers an open-source solution for feature-flagging, gradual roll-outs, and split-testing. Official SDKs simplify consumption from multiple clients and stacks."
 VSCode pairing,trial,tools,TRUE,
 Redux,assess,languages & frameworks,FALSE,
 Apollo Server,assess,platforms,TRUE,
@@ -45,8 +47,8 @@ Datadog Synthetics,assess,tools,TRUE,
 HashiCorp Vault,assess,tools,TRUE,
 Helm,assess,tools,TRUE,
 Coffeescript,hold,languages & frameworks,FALSE,
+Objective-C,hold,languages & frameworks,FALSE,"Because we use React Native some amount of Objective-C bridging code will remain necessary, these should be thin layers to swift features. Some legacy core Eigen infrastructure and React Native itself is written in Objective-C."
 Scala,hold,languages & frameworks,FALSE,
-Swift,adopt,languages & frameworks,FALSE,"We generally opt for React Native, but when necessary for quality, usability or features tightly integrated with OS, we will build native features in Swift using UIKit. see Objective-C."
 AWS Lambda,hold,platforms,TRUE,
 Google cloud,hold,platforms,FALSE,
 Heroku,hold,platforms,FALSE,"We prefer kubernetes where we have shared solutions for authorization, logging, monitoring, alerting, scaling, and routing."
@@ -58,7 +60,9 @@ Serverless architecture,hold,techniques,TRUE,
 Consul,hold,tools,FALSE,
 Jenkins CI/CD,hold,tools,FALSE,
 Kafka,hold,tools,FALSE,
+LabFeatures (Gravity),hold,tools,TRUE,"Unleash supports similar feature-enabling on an individual account basis, while also being flexible enough for gradual roll-outs and split tests."
 MongoDB,hold,tools,FALSE,
 Pingdom,hold,tools,TRUE,
 Semaphore,hold,tools,FALSE,
+SiteFeatures (Gravity),hold,tools,TRUE,"Site Features were used to turn on or off core functionality, but are easily replaced by Unleash (for platform-wide toggles) or Flipper (for Gravity-only settings)."
 Travis CI,hold,tools,TRUE,


### PR DESCRIPTION
There's been a lot of interest in feature-flagging and split-testing recently. A few trials of specific tools are in intermediate states while we evaluate or unwind them, so let's make that more clear in our tech radar. Specifically:

* **Trial Unleash for feature-flagging and split-testing**. Support has been added to 2 back-end systems so far, and work is in progress (or planned) to integrate it into clients like Force and Eigen. Integrating into multiple clients is worthwhile despite not yet being fully "adopted," because how the service operates across the platform and stacks is an important element of this evaluation. There's some risk of wasted work, but little long-term maintenance burden because client SDKs fall back to defaults when the service is unavailable. <Debate...?>
* **Avoid new `LabFeature`s** since they're easily replaced by Unleash's built-in "user ID strategy."
* **Avoid new `SiteFeature`s** since they're easily replaced by Unleash's built-in "standard strategy."
* Document that **we strive to split-test product changes** in parallel, rather than simply monitoring metrics after the fact. Due to the seasonality and event-sensitive nature of our product, retroactive monitoring is hardly enough to confirm that product improvements are actually that.

The interactive version of these changes can be viewed [here](https://radar.thoughtworks.com/?sheetId=https%3A%2F%2Fraw.githubusercontent.com%2Fartsy%2Freadme%2FjoeyAghion%2fradar-unleash%2Fplaybooks%2Ftechnology_radar%2Fartsy-tech-radar.csv).

**Q:** Should we document Split.io's "hold" status here, or is that already obvious enough to anyone involved?

Note: other diffs are automated and unrelated.