### PR TITLE
fix: aws-iam-authenticator instruction

### DIFF
--- a/playbooks/hokusai.md
+++ b/playbooks/hokusai.md
@@ -38,10 +38,7 @@ See https://github.com/artsy/hokusai#setup
 ### Configure Hokusai
 
 Prerequisite: install the AWS IAM Authenticator plugin
-
-```
-brew install aws-iam-authenticator
-```
+A specific version is required to work with our Kubernetes config files. Please see our [setup script](https://github.com/artsy/potential/blob/main/scripts/setup).
 
 _Make sure IAM credentials are set in your shell via AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables or ~/.aws/credentials!_
 

--- a/playbooks/hokusai.md
+++ b/playbooks/hokusai.md
@@ -37,7 +37,7 @@ See https://github.com/artsy/hokusai#setup
 
 ### Configure Hokusai
 
-Prerequisite: install the aws-iam-authenticator plugin
+Prerequisite: install the [aws-iam-authenticator](https://github.com/kubernetes-sigs/aws-iam-authenticator) plugin
 
 A specific version is required to work with our Kubernetes config files. Please see our [setup script](https://github.com/artsy/potential/blob/main/scripts/setup).
 

--- a/playbooks/hokusai.md
+++ b/playbooks/hokusai.md
@@ -37,7 +37,8 @@ See https://github.com/artsy/hokusai#setup
 
 ### Configure Hokusai
 
-Prerequisite: install the AWS IAM Authenticator plugin
+Prerequisite: install the aws-iam-authenticator plugin
+
 A specific version is required to work with our Kubernetes config files. Please see our [setup script](https://github.com/artsy/potential/blob/main/scripts/setup).
 
 _Make sure IAM credentials are set in your shell via AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables or ~/.aws/credentials!_


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4009

Point to Potential setup script which installs a specific version of `aws-iam-authenticator`.