### PR TITLE
doc: add documentation around adding new config variables

### DIFF
--- a/playbooks/development-environments.md
+++ b/playbooks/development-environments.md
@@ -90,6 +90,11 @@ To _update_ shared configuration values, simply modify `.env.shared` and re-uplo
 
     aws s3 cp .env.shared s3://artsy-citadel/dev/.env.zulu
 
+If you are _adding_ a new configuration value, you need to run additional cmds:
+
+    hokusai [staging|production] env set NEW_ENV_VARIABLE=<value>
+    hokusai [staging|production] refresh
+
 ## Examples
 
 - [Gravity's `script/setup`](https://github.com/artsy/gravity/blob/master/bin/setup)🔒


### PR DESCRIPTION
Adding some more documentation about environment variables.
For more context, see [thread](https://artsy.slack.com/archives/CA8SANW3W/p1646681796877969).