### PR TITLE
chore: update Lunch & Learn references => Knowledge Share

### DIFF
--- a/events/README.md
+++ b/events/README.md
@@ -10,7 +10,7 @@ What meetings, and regular events do we have.
 | [Artsy Learns to Code](/events/artsy-learns-to-code.md#readme) | Experimental structure where we teach non-engineering colleagues how to code. |
 | [Demo Days](/events/demo-days.md#readme) | How we showcase shipped projects |
 | [Happy Hours](/events/happy-hour.md#readme) | When all of Artsy comes together with partners, friends, artists and engineers. |
-| [Lunch & Learn](/events/lunch-and-learn.md#readme) | A meetup where we talk about things that inspire us. |
+| [Knowlege Share](/events/knowledge-share.md) | A meetup where we share knowledge formally and informally across the org. |
 | [Open Standup](/events/open-standup.md#readme) | How do we do whole-team standup at Artsy? |
 | [Peer Labs](/events/peer-labs.md#readme) | Running the peer labs meetup at Artsy |
 | [Show & Tell](/events/show-and-tell.md#readme) | Internal presentations with no preparation |

--- a/events/knowledge-share.md
+++ b/events/knowledge-share.md
@@ -1,9 +1,9 @@
 ---
-title: Lunch & Learn
-description: A meetup where we talk about things that inspire us.
+title: Knowledge Share
+description: A meetup where we share knowledge formally and informally across the org
 ---
 
-# Lunch & Learn
+# Knowledge Share
 
 When Artsy was under 50 people, we would hold "Brown Bag" meetings. These were
 talks on a variety of art+science topics. As we out-grew the format, we started
@@ -13,11 +13,9 @@ This worked for a while, but was sporadic and mostly the same speakers. Once we
 moved to [a new stand-up format][standup_post] it felt like time to re-vamp our
 brown bags too.
 
-[standup_post]: https://artsy.github.io/blog/2015/03/23/artsy-technology-stack-2015/
+[standup_post]: https://artsy.github.io/blog/2018/05/07/fully-automated-standups/
 
-Our format is pretty simple, every other Thursday we have an hour slot at 12:30
-(NYC time) on the calendar for someone to give a talk or presentation. I think
-[Alan][alan] described it well on [Professional Development at
+For a few years we ran a weekly "Lunch & Learn" on Thursdays to educate the team about our stack, business proceses, recent projects, or other interesting technical topics. [Alan][alan] described it well on [Professional Development at
 Artsy][alan_post]:
 
 [alan]: https://twitter.com/alanjay1/
@@ -26,12 +24,17 @@ Artsy][alan_post]:
 > Every Thursday, we do a Lunch-and-Learn session. Historically, we mostly
 > showed off tech we use internally. But over about a year, most of our tech
 > stack has been presented this way, so we also bring in engineers we know at
-> other companies to share what they’re working on.
+> other companies
 
-On the off weeks we have a [Show & Tell](show-and-tell.md) and those weeks where
-we can't find a Lunch & Learn speaker we fall back to doing Show & Tell.
 
-So far, from external contributors we've had:
+After a while we decided to mix things up by:
+
+- Inviting the occasional external speaker (see some examples below)
+- Alternating formal, scheduled Lunch & Learns with informal, open-mic style [Show & Tells](show-and-tell.md)
+
+As the team has grown and become more international (and no longer lunches around the same time), we've renamed this event to Engineering Knowledge Share. We still aim to alternate between formal presentations, and informal show-and-tells.
+
+In the past we've had external contributors, for example:
 
 - How Buffer does Transparency by [Katie Womersley](https://twitter.com/‪katie_wormers‬)
 - How I got started in OSS by [Henry Zhu](https://twitter.com/‪left_pad) of Babel/Behance
@@ -66,17 +69,21 @@ Here are some examples of internal presentations:
 - How we use [Hokusai](https://github.com/artsy/hokusai) to deploy software
 - How to use vim
 
+If you are an Artsy employee you can find an archive of many, many more such topics in our [archives][google_drive_presentation_archive].
+
+[google_drive_presentation_archive]: https://drive.google.com/drive/folders/1X8w7iFbdeVwi6v_xWLWfQdeJ81iewYWB?usp=sharing
+
 ---
 
-You're probably seeing this as an external developer to Artsy, who has been
-invited to talk.
+You may be seeing this as an external developer to Artsy, who has been
+invited to talk, or as an internal colleage who's been asked to give a presentation.
 
 ## Format
 
 The format is definitely not set in stone, however these are what has worked for
 us internally and for past contributors.
 
-#### Presentation
+### Presentation
 
 Traditional conference/meetup style: You bring slides, we watch. You talk, we
 listen. You finish, we ask questions.
@@ -84,30 +91,11 @@ listen. You finish, we ask questions.
 We don't expect conference/meetup-level presentation or practice. A lack of
 polish is okay. This is a great opportunity to present new talks ideas.
 
-#### Company Walkthrough
+### Company Walkthrough
 
 More informal, you can come with other speakers and talk about the ways in which
 your company works. Covering your tech stack, the decisions behind them. With
 the presentation mainly being a series of demos, and showing code architecture.
-
-## Schedule
-
-- Arrive at Artsy by 12:15pm ([401 Broadway, 26th Floor, 10013][401] - Canal St
-  is the closest station)
-- Our receptionist on 26 will get in touch with whoever you've been in contact
-  with, probably [Ash][] or [Justin][]
-- They will get you set up on our 27th floor Classroom
-- We will set up [a stream](#recording) for global developers and slides
-- We have until 12:30 to get any technical difficulties sorted out ([the docs
-  are here][trouble])
-- You give a presentation (~30 minutes)
-- We ask a bunch of questions (~15 minutes)
-- Whoever helped get you set up takes you out for lunch on us
-
-Artsy Engineering now owes you, and your company [a talk back][ash_talk]. Feel
-free to arrange that whenever you like.
-
-[ash_talk]: https://speakerdeck.com/ashfurrow/teaching-and-learning-1
 
 ## Recording
 
@@ -116,6 +104,7 @@ We ask that we can share a livestream of your talk, because we have a lot of
 your computer and sharing your screen.
 
 [global_post]: https://www.artsy.net/article/eloy-duran-going-global-5-tips-to-make-remote-work
+[zoom.us]: https://zoom.us
 
 We also ask that we get a recording of the talk (kept internal within Artsy),
 for colleagues who couldn't attend or want to review your awesome talk later.
@@ -126,10 +115,3 @@ a copy of the recording.
 **If you don't want to be recorded, no problem**. We understand that you might
 talk and show things that are not for public consumption. We will not share
 anything externally without your express permission.
-
-[Roop]: https://github.com/anandaroop
-[ash]: https://github.com/ashfurrow
-[justin]: https://github.com/zephraph
-[401]: https://www.google.com/maps/place/401+Broadway/@40.718958,-74.0049492,17z/data=!3m1!4b1!4m5!3m4!1s0x89c2598a7196824f:0xddf53435afbdd5b9!8m2!3d40.718954!4d-74.0027552
-[trouble]: https://github.com/artsy/README/blob/master/playbooks/running-lunch-and-learn.md#troubleshooting
-[zoom.us]: https://zoom.us

--- a/events/open-standup.md
+++ b/events/open-standup.md
@@ -22,7 +22,7 @@ The person handling the talking parts does this stuff ten minutes before standup
 - `@here`s the dev channel. Include where the meeting is in the NYC office (usually the Annex).
 - Make sure on-call staff are prepared to give an update about the past week's incidents. (if you were on call,
   great! If you weren't, remind your partner.)
-- Check the [Lunch&Learn schedule][ll_schedule].
+- Check the [Knowledge Share schedule][ks_schedule].
 - The meeting starts with props (as a nod towards [People are Paramount][pplp]) and you should begin with giving
   props of your own.
 
@@ -87,7 +87,7 @@ _Peer Learning Group Updates_
 
 -
 
-_Lunch & Learn_ || _Show & Tell_ (if you don't know, ask in #lunch_and_learn or #dev-show-n-tell)
+_Knowledge Share_
 
 -
 
@@ -101,7 +101,7 @@ _Optional: Q&A / Open Discussion_
 ```
 
 [pplp]: https://github.com/artsy/README/blob/master/culture/what-is-artsy.md#people-are-paramount
-[ll]: https://github.com/artsy/README/blob/master/events/lunch-and-learn.md
-[ll_schedule]: https://github.com/artsy/README/projects/1
+[ll]: https://github.com/artsy/README/blob/master/events/knowledge-share.md
+[ks_schedule]: https://github.com/artsy/README/projects/1
 [notion]: https://www.notion.so/artsy/Standup-Notes-28a5dfe4864645788de1ef936f39687c
 [standup_blog]: https://artsy.github.io/blog/2018/05/07/fully-automated-standups/

--- a/events/show-and-tell.md
+++ b/events/show-and-tell.md
@@ -11,9 +11,10 @@ working on. These short talks/demos/code reviews are not meant to be polished
 presentations, but instead impromptu ways we can share lessons learned and cool
 things discovered!
 
-This happens at the same time slot as [Lunch & Learn](lunch-and-learn.md) and we
-alternate between the two events. On Lunch & Learn weeks without a speaker lined
-up, we fall back to doing a bonus Show & Tell.
+This happens at the same time slot as [Knowledge Share](knowledge-share.md),
+where we alternate between these informal show & tells, and more formal
+presentations. On Knowledge Share weeks without a formal speaker lined up,
+we fall back to doing a bonus Show & Tell.
 
 Previous demos include:
 

--- a/events/writing-office-hours.md
+++ b/events/writing-office-hours.md
@@ -13,9 +13,9 @@ Here are some examples of good uses of Writing Office Hours:
 - You'd like to write a blog post but don't know where to start.
 - There is a conference you're thinking of submitting to and want some feedback on your application.
 - There's an important email you have to write.
-- You're presenting a [Lunch & Learn][lnl] to the team and want to go through a dry run first.
+- You're presenting a [Knowledge Share][ks] to the team and want to go through a dry run first.
 - You will be a guest on a podcast and want to organize some thoughts first.
 - You have _most_ of a blog post written out, but want help getting it over the finish line.
 
 [ash]: https://github.com/ashfurrow
-[lnl]: ./lunch-and-learn.md
+[ks]: ./knowledge-share.md

--- a/onboarding/engineering-introduction.md
+++ b/onboarding/engineering-introduction.md
@@ -39,7 +39,7 @@ We have an engineering team-wide standup on _Mondays at 12:00 p.m. Eastern_ wher
 - Share any team updates
 - Mention significant project milestones or new repositories
 - Ask for help if we're blocked or need input from a different team
-- Plan the week's _lunch and learn_
+- Plan the week's _knowledge share_
 - Recognize and congratulate each other for significant accomplishments
 
 The standup is fully documented [here](/events/open-standup.md).
@@ -172,11 +172,11 @@ More about [continuous improvement](/playbooks/engineer-workflow.md#continuous-i
 
 ### Project Management / Sprints
 
-Teams at Artsy work with product management via [Jira](https://artsyproduct.atlassian.net/) 🔒. Teams tend to work in 2 week sprints, with a planning meeting at the start and a review/retrospective at the end. 
+Teams at Artsy work with product management via [Jira](https://artsyproduct.atlassian.net/) 🔒. Teams tend to work in 2 week sprints, with a planning meeting at the start and a review/retrospective at the end.
 
 ### Future Fridays
 
-PDDE-wide, the 2nd Friday of each sprint is "Future Friday." This is a lightweight process focused on collecting ideas about longer-term opportunities during the course of day-to-day work. 
+PDDE-wide, the 2nd Friday of each sprint is "Future Friday." This is a lightweight process focused on collecting ideas about longer-term opportunities during the course of day-to-day work.
 
 Conversations can be labeled with #ff so they're find-able later. When Friday comes (if you're so compelled), choose a direction to explore/experiment and report back any results at end-of-day. Participation is optional and collaborations are encouraged.
 

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -44,7 +44,7 @@ practice should be incorporated, submit a PR!
 | [Renaming master branches to main](/playbooks/rename-master-to-main.md#readme) | a CLI to manage applications deployed to Kubernetes |
 | [How to run a retrospective](/playbooks/retrospectives.md#readme) | The why and how for running a retrospective |
 | [How to create an RFC at Artsy](/playbooks/rfcs.md#readme) | The steps needed to request cultural changes |
-| [How to run a Lunch & Learn](/playbooks/running-lunch-and-learn.md#readme) | How to handle the people process for Lunch & Learns |
+| [How to run a Knowledge Share](/playbooks/running-knowledge-share.md) | How to handle the people process for Knowledge Shares |
 | [System Criticality](/playbooks/system-criticality.md#readme) | A framework for treating systems differently according to how critical they are |
 | [Taming notifications](/playbooks/taming-notifications.md#readme) | How to set up notifications so that they leave you alone outside of working hours |
 | [Technology choices](/playbooks/technology-choices.md#readme) | How to make technology decisions at Artsy |

--- a/playbooks/engineer-workflow.md
+++ b/playbooks/engineer-workflow.md
@@ -41,12 +41,12 @@ README if you want to know who to start asking questions to.
 Artsy teams prefer to work in branches on a shared repository rather than forks. This means that developers should
 clone the repo, create a working branch from `main`, then push that branch back to the main repo.
 [Pull requests](#pull-requests) are then made from the working branch back to the `main` branch. For tidiness,
-working branches should be named by their creator like `<github_user_name>/<prefix>/<topic>`, even when a 
+working branches should be named by their creator like `<github_user_name>/<prefix>/<topic>`, even when a
 collaboration.
 
-Wait, what? What prefix? We use [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) prefixes in our 
-PR titles, because by default, we squash our commits when merging a PR, and this means that the squashed commit 
-automatically ends up using the conventional commit format. Using the prefix in your branch name is not essential, 
+Wait, what? What prefix? We use [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) prefixes in our
+PR titles, because by default, we squash our commits when merging a PR, and this means that the squashed commit
+automatically ends up using the conventional commit format. Using the prefix in your branch name is not essential,
 but it's, well, nice.
 
 ### Commits
@@ -90,9 +90,9 @@ Once again, the title should concisely explain the change or addition. The descr
 Include any details that add context to the PR, as
 [reviewers likely have less context than you](https://artsy.github.io/blog/2020/08/11/improve-pull-requests-by-including-valuable-context/).
 
-As mentioned above, PRs will be squashed when merged, unless there's a good reason not to (see the [RFC](https://github.com/artsy/README/issues/327) 
-that initiated this practice for more explanation and discussion). When they're squashed the title of the PR will 
-be used for the single squashed commit, so make sure that you use [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) 
+As mentioned above, PRs will be squashed when merged, unless there's a good reason not to (see the [RFC](https://github.com/artsy/README/issues/327)
+that initiated this practice for more explanation and discussion). When they're squashed the title of the PR will
+be used for the single squashed commit, so make sure that you use [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/)
 format in your PR title.
 
 #### Assignees and Reviewers
@@ -207,7 +207,7 @@ The tools of change, including aggressive **refactoring**, **data migrations**, 
 our efforts, so are worth significant investment despite being disconnected from user-facing features.
 
 Finally, Artsy aims for a culture of continuous improvement to both code _and_ process. We try to share wins, teach
-best practices and offer constructive feedback. Tools like lunch-and-learns,
+best practices and offer constructive feedback. Tools like knowledge-shares,
 [postmortems](https://github.com/artsy/post_mortems) 🔒, [kaizen](https://en.wikipedia.org/wiki/Kaizen) or
 [retrospectives](https://en.wikipedia.org/wiki/Retrospective) help us reflect on our own practices and make change.
 

--- a/playbooks/running-knowledge-share.md
+++ b/playbooks/running-knowledge-share.md
@@ -1,31 +1,30 @@
 ---
-title: How to run a Lunch & Learn
-description: How to handle the people process for Lunch & Learns
+title: How to run a Knowledge Share
+description: How to handle the people process for Knowledge Shares
 ---
 
-# Running a Lunch & Learn
+# Running a Knowledge Share
 
-Hello Artsy employee or curious outsider! This document outlines how to run our [lunch and learns][event]. The
-process of planning a L&L spans weeks and generally goes through the following steps. The planning process is
-managed in the [Lunch and Learns GitHub project][project].
+Hello Artsy employee or curious outsider! This document outlines how to run our [knowledge shares][event]. The
+process of planning a KS generally goes through the following steps. The planning process is
+managed in the [Knowledge Shares GitHub project][project].
 
-If you're interested in speaking at one of our lunch and learns, you can find out all about [it here][event]
+If you're interested in speaking at one of our knowledge shares, you can find out all about [it here][event]
 
-- **Ideas**: These can be either people we'd like to present or ideas that we'd like to find speakers for – either
-  Artsy employees or external speakers we'd like to invite in.
-- **In Conversation**: We have reached out and are in talks with someone specific to present a L&L.
+- **Ideas**: These can be either people we'd like to present or ideas that we'd like to find speakers for – either Artsy employees or external speakers we'd like to invite in.
+- **In Conversation**: We have reached out and are in talks with someone specific to present a KS
 - **Scheduled**: A date has been confirmed with the speaker and they have received a calendar event invitation.
-- **Add to Docs/Dropbox/YouTube**: The presentation is finished but needs to be documented ([see below][after]).
+- **Add to README/Google Drive**: The presentation is finished but needs to be documented ([see below][after]).
 - **Done**: It's done!
 
 Read on for more specifics.
 
 ## Suggesting a Presenter
 
-Are you an Artsy employee? Do you want to suggest someone to present a Lunch & Learn? Great!
+Are you an Artsy employee? Do you want to suggest someone to present a Knowledge Share? Great!
 
-- Go to the #lunch-and-learn Slack channel and let us know
-- Add a card to the [project][] in the appropriate column
+- Go to the #dev-knowledge-share Slack channel and let us know
+- Add a card to the [project][project] in the appropriate column
 
 We encourage you to follow the rest of this guide. You've got this! And if you need help, or would prefer someone
 take over from you, just let the Slack channel know.
@@ -36,14 +35,14 @@ Sometimes you'll get an introduction to a speaker from a colleague, passing the 
 event. Just follow these steps:
 
 - Say thanks!
-- Pass along the link to the [lunch_and_learn.md][event].
-- Add a card to the "In Conversation" section of the [Lunch and Learn project][project], or move the existing card
+- Pass along the link to the [knowledge-share.md][event].
+- Add a card to the "In Conversation" section of the [Knowledge Share project][project], or move the existing card
   there from "Ideas".
 - Discuss what topic makes sense.
 - Pick a date and move their card to the "Scheduled" column (and add the date to the card title). Send them a
   calendar invitation.
 
-## Running a Lunch & Learn
+## Running a Knowledge Share
 
 ### The Monday Before
 
@@ -57,36 +56,32 @@ event. Just follow these steps:
 
 ### The Day Of
 
-We have The Classroom booked from 12:00–12:30 for setup, so go check at noon that everything is working:
+If this is an IRL presentation from an external speaker, make sure there is a Zoom room booked and
 
 - [ ] TV is turned on.
 - [ ] Zoom iPad is on and plugged in.
 
-Be on 26 at 12:10 to receive our guest (they should have been asked to arrive at 12:15). Take them upstairs and
-while they're getting set up, offer some water. Get them set up on the Zoom.us meeting and remind them that you'll
+Receive our guest (they should have been asked to arrive at 15 minutes early). While they're getting set up, offer some water. Get them set up on the Zoom.us meeting and remind them that you'll
 take them out for lunch afterward.
 
-At 12:20, send an `@here` reminder in the #dev (also post in #general if applicable). Give folks a few minutes past
-12:30 to show up, but don't hold the show up waiting for them.
+Ten minutes beforehand, send an `@here` reminder in the #dev (also post in #general if applicable). Give folks a few minutes past to show up, but don't hold the show up waiting for them.
 
-Immediately before you present the speaker, hit the record button in Zoom.us and it'll ask you for your email
-address.
+Immediately before you present the speaker, hit the record button in Zoom.us and it'll ask you for your email address.
 
 ### Afterward
 
 Right after the talk, ask the speaker for their slides. Check to make sure it's okay for us to thank them on
-Twitter. Then take the speaker and a few folks out to lunch. Tataki is never a bad choice. Make sure to expense
+Twitter. Then take the speaker and a few folks out to lunch. Tataki is never a bad choice in NYC. Make sure to expense
 this meal.
 
-Later, Zoom.us will email you the video recording. Upload the video and the slides to the [Everyone at Artsy/Lunch
-& Learn Dropbox folder][dropbox-folder] and post a link to Slack. Use the following convention to name the
+Later, Zoom.us will email you the video recording. Upload the video and the slides to the [Google Drive archive][google_drive_presentation_archive] and post a link to Slack. Use the following convention to name the
 subfolder:
 
 ```
 YYYY-MM-DD <presentation title> with <speaker name>
 ```
 
-Send a pull request to the [Lunch and Learn docs][event] that adds the speaker to the list. Make sure to thank the
+Send a pull request to the [Knowledge Share docs][event] that adds the speaker to the list. Make sure to thank the
 speaker again over email, offer a copy of the video, and reiterate that we owe them a talk now.
 
 If the talk was given by an Artsy colleague, ask them if it would be appropriate to upload to YouTube for public
@@ -97,8 +92,7 @@ If the talk was given by someone outside Artsy, log into the [@ArtsyOpenSource t
 
 Move the card to the "Done" column. Nice work!
 
-[dropbox-folder]: https://www.dropbox.com/home/Everyone%20at%20Artsy/Lunch%20%26%20Learn
-
+[google_drive_presentation_archive]: https://drive.google.com/drive/folders/1X8w7iFbdeVwi6v_xWLWfQdeJ81iewYWB?usp=sharing
 ### Troubleshooting
 
 ##### Connecting to the screen
@@ -130,5 +124,5 @@ Move the card to the "Done" column. Nice work!
 [after]: #Afterward
 [blog]: https://github.com/artsy/artsy.github.io
 [project]: https://github.com/artsy/README/projects/1
-[event]: ../events/lunch-and-learn.md
+[event]: ../events/knowledge-share.md
 [twitter]: https://twitter.com/ArtsyOpenSource

--- a/playbooks/technology-choices.md
+++ b/playbooks/technology-choices.md
@@ -75,8 +75,8 @@ trial either way. Avoid trialing multiple unproven things in the same project or
 
 #### We've had a positive experience with _Phoenix_ (e.g.) and should adopt it in more places.
 
-Congrats! Is there a critical mass of engineers (`>=3`) comfortable working with this tech? If so, consider a lunch
-& learn or practice meeting discussion to review your experience and share any lessons. Make a pull request to the
+Congrats! Is there a critical mass of engineers (`>=3`) comfortable working with this tech? If so, consider a Knowledge Share
+or practice meeting discussion to review your experience and share any lessons. Make a pull request to the
 radar and make sure to request comments from the relevant engineers or experts. Remember that it may not be
 sufficient to just "adopt" a new choice. If this replaces an alternative that's in place at Artsy, that should
 probably move to "hold" and a strategy be decided for migrating away from the old tech (e.g., opportunistically or

--- a/resources/README.md
+++ b/resources/README.md
@@ -10,7 +10,7 @@ Listicles, but on GitHub.
 | [Our highlight links about Artsy](/resources/artsy.md#readme) | An overview of links about Artsy and some of our bigger packaged Art content. |
 | [Highlights from our engineering blog](/resources/blog.md#readme) | The best-of from our archives |
 | [Leadership resources](/resources/leadership.md#readme) | The best-of from our [#leadership](https://artsy.slack.com/messages/leadership) 🔒 slack channel |
-| [Highlights from our L&Ls](/resources/lnl.md#readme) | The best-of from our archives |
+| [Highlights from our Knowledge Shares](/resources/ks.md#readme) | The best-of from our archives |
 | [How to get started on any of our tech stacks](/resources/tech-learning.md#readme) | The getting started guides |
 <!-- end_toc -->
 <!-- prettier-ignore-end -->

--- a/resources/ks.md
+++ b/resources/ks.md
@@ -1,10 +1,11 @@
 ---
-title: Highlights from our L&Ls
+title: Highlights from our Knowledge Shares
 description: The best-of from our archives
 ---
 
-Recordings of past lunch and learns can be found in the Shared Google Drive under
-[__Everyone at Artsy/PDDE/Engineering/Lunch & Learn](https://drive.google.com/drive/u/0/folders/1X8w7iFbdeVwi6v_xWLWfQdeJ81iewYWB)
+Recordings of past Knowledge Shares (formerly "Lunch & Learns") can be found in the [shared Google Drive][google_drive_presentation_archive].
+
+[google_drive_presentation_archive]: https://drive.google.com/drive/folders/1X8w7iFbdeVwi6v_xWLWfQdeJ81iewYWB?usp=sharing
 
 ## Artsy's business
 

--- a/spellcheck.json
+++ b/spellcheck.json
@@ -1,4 +1,4 @@
 {
   "ignore": [],
-  "whitelistFiles": ["events/lunch_and_learn.md"]
+  "whitelistFiles": ["events/knowledge-share.md"]
 }


### PR DESCRIPTION
Now that we've rebranded **Lunch & Learn || Show & Tell** as simply **Knowledge Share** this updates a bunch of documentation accordingly.

There are still several references/instructions relating to IRL presentations with external speakers. I've updated but not totally removed these, because maybe this will become a thing again someday 🤷🏽 