### PR TITLE
RFC: Enable Automerging Feauture for Dependabot PRs

### DIFF
--- a/playbooks/dependencies.md
+++ b/playbooks/dependencies.md
@@ -78,6 +78,23 @@ The advantages are that this code is unlikely to surprise us in the future (beca
 code) and there are less chances of hitting dependency issues (because it cannot be the dependency of another
 dependency.)
 
+## Automatically updating Dependencies with Dependabot
+
+In most of our repositories we have dependabot enabled (through github). You can find the configurations for the dependabot PRs for a repository in a file called _dependabot.yml_ where things like the package ecosystem and the interval for checking updates are defined. Here is an example:
+```yml
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: daily
+    # Limit to 0 to enable only security updates:
+    open-pull-requests-limit: 0
+    assignees:
+      - fclesio
+    reviewers:
+      - artsy/data-platform
+```
 ## Notes
 
 Prior Artsy engineer’s writing on the topic of dependency management:


### PR DESCRIPTION
## Proposal:

We are currently already using dependabot for automatic library version updates. But we still have to merge every one of these updates manually. Let's use the automerging feature from github actions for these dependabot PRs. We could restrict the automerging to minor version updates (or even to only patch updates). And of course we would allow automerging only to the staging environment and only when CI is green. Also this decision would have to be made repo by repo so projects that are not a good fit for the feature (like Eigen) could be excluded. 

Find implementation details in this [tech plan](https://www.notion.so/artsy/Github-actions-allows-dependabot-auto-merge-when-CI-green-45c5213924064657ae2ba5b40c2960d1).

## Reasoning

Most of the dependabot update PRs are trivial and if the CI is green there is no reason to assume that the update would break something. The automerging feature of the github native dependabot is a nice way to reduce the noise for these trivial updates and free up developer’s minds for more interesting work. 
On the other side _not_ merging these updates would hurt us more in the long run and like that we could insure to keep up with the updates more easily.

## Exceptions:

Eigen and other repositories that have requirements for manual backchecking of library updates.


## Additional Context:

You can see our discussion [in slack here](https://artsy.slack.com/archives/C01GNGC4XEZ/p1651077831087519)

## How this RFC is resolved

We'll collect feedback on this RFC from the team for a week. We'll consider this RFC approved
if 50% of the engineering team does not disapprove of this change. Add a 👍 or 👎  reaction to
this proposal to vote.