### PR TITLE
feat: minor update after k8s upgrade

### DIFF
--- a/playbooks/hokusai.md
+++ b/playbooks/hokusai.md
@@ -48,7 +48,7 @@ If you have the [aws cli](https://docs.aws.amazon.com/cli/latest/userguide/cli-c
 Also make sure you set your default region to `us-east-1` either via config or by setting the environment variable `AWS_DEFAULT_REGION=us-east-1`
 
 ```
-hokusai configure --kubectl-version 1.18.10 --s3-bucket artsy-citadel --s3-key k8s/config-dev
+hokusai configure --kubectl-version 1.19.16 --s3-bucket artsy-citadel --s3-key k8s/config-dev
 ```
 
 #### Note

--- a/playbooks/kubernetes.md
+++ b/playbooks/kubernetes.md
@@ -25,8 +25,8 @@ The dashboards for our Kubernetes application clusters can be found at:
 ### Monitoring
 We use [Datadog](https://app.datadoghq.com/) for cluster monitoring and alerting.
 
-- [Production Cluster Overview](https://app.datadoghq.com/infrastructure/map?mapid=4312&fillby=avg%3Acpuutilization&sizeby=avg%3Asystem.mem.used&groupby=autoscaling_group%2Cavailability-zone&filter=kubernetescluster%3Akubernetes-production-pictor.artsy.systems&nameby=name&nometrichosts=false&tvMode=false&nogrouphosts=false&palette=green_to_orange&paletteflip=false&node_type=host)
-- [Staging Cluster Overview](https://app.datadoghq.com/infrastructure/map?mapid=4320&fillby=avg%3Acpuutilization&sizeby=avg%3Asystem.mem.used&groupby=autoscaling_group%2Cavailability-zone&filter=kubernetescluster%3Akubernetes-staging-leo.artsy.systems&nameby=name&nometrichosts=false&tvMode=false&nogrouphosts=false&palette=green_to_orange&paletteflip=false&node_type=host)
+- [Production Cluster Overview](https://app.datadoghq.com/infrastructure/map?fillby=avg%3Acpuutilization&filter=env%3Aproduction&groupby=availability-zone%2Ck8s.io%2Fcluster-autoscaler%2Fnode-template%2Flabel%2Ftier)
+- [Staging Cluster Overview](https://app.datadoghq.com/infrastructure/map?fillby=avg%3Acpuutilization&filter=env%3Astaging&groupby=availability-zone%2Ck8s.io%2Fcluster-autoscaler%2Fnode-template%2Flabel%2Ftier)
 - [Container Overview](https://app.datadoghq.com/containers?columns=container_name,container_cpu,container_memory,container_net_sent_bps,container_net_rcvd_bps,container_status,container_started&options=normalizeCPU&sort=container_memory,DESC)
 
 ### Allocating Kubernetes resources for apps.


### PR DESCRIPTION
- Update `kubectl` version.
- Datadog links currently hardcode Kubernetes cluster names which change at every Kubernetes upgrade. Let the links refer to `production` and `staging` so we won't have to change them much. 