### PR TITLE
RFC: Add a dev-announce channel for engineering-wide announcements

### DIFF
--- a/culture/slack.md
+++ b/culture/slack.md
@@ -13,6 +13,7 @@ Slack for all internal messaging, and prefer it to email in, basically, all case
 
 You should always feel up to date on these two:
 
+- [#dev-announce](https://artsy.slack.com/messages/dev-announce)🔒: Engineering announcements. No chatter outside of thread responses.
 - [#dev](https://artsy.slack.com/messages/dev) 🔒: Engineering-wide chat.
 - [#dev-offtopic](https://artsy.slack.com/messages/dev-offtopic) 🔒: Engineers chatting about less timely and
   work-relevant topics.

--- a/culture/slack.md
+++ b/culture/slack.md
@@ -34,7 +34,7 @@ Engineering teams each maintain a dedicated channel (but all are welcome):
 - Find & Explore: [#product-find-explore](https://artsy.slack.com/messages/product-find-explore) 🔒
 - Grow: [#product-grow](https://artsy.slack.com/messages/product-grow) 🔒
 - Partner Experience: [#product-partner-experience](https://artsy.slack.com/messages/product-partner-experience) 🔒
-- Veloity (formerly known as Platform): [#product-velocity](https://artsy.slack.com/messages/product-velocity) 🔒
+- Velocity (formerly known as Platform): [#product-velocity](https://artsy.slack.com/messages/product-velocity) 🔒
 - Purchase: [#product-purchase](https://artsy.slack.com/messages/product-purchase) 🔒
 
 Some other channels engineers might find helpful:


### PR DESCRIPTION
## Proposal:

Add a dev-announce channel for announcements that impact the engineering team.

Some examples:
* Deploy locks
* Breaking changes
* Tooling & infrastructure upgrades
* Structural changes impacting the eng org (e.g. new teams, staffing changes, new processes)
* GitHub (or another external dev service) is down

**To avoid folks getting excessive notifications, there will be a zero-chatter policy except in threads.**

## Reasoning

Messages tend to get lost among the automated bot notifications and the general chatter when shared in #dev, this results in a loss of context that only gets bigger if things have been shared during someone's time off. Additionally, because all the dev-related announcements land in the same place, it eliminates hierarchy and leads us to rely on the @devs tag to signal messages with impact at the org level.  

## How this RFC is resolved

**We'll collect feedback on this RFC from the team for two weeks.**  We'll consider this RFC approved
if 50% of the engineering team actively approves of this change. Add a 👍 or 👎  reaction to
this proposal to vote.
