### PR TITLE
RFC: Adds Technical planning document

### DIFF
--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -48,7 +48,7 @@ practice should be incorporated, submit a PR!
 | [System Criticality](/playbooks/system-criticality.md#readme) | A framework for treating systems differently according to how critical they are |
 | [Taming notifications](/playbooks/taming-notifications.md#readme) | How to set up notifications so that they leave you alone outside of working hours |
 | [Technology choices](/playbooks/technology-choices.md#readme) | How to make new technology decisions at Artsy |
-| [Technical planning](/playbooks/technical-planning.md#readme) | How to write technical plans at Artsy |
+| [Technical planning](/playbooks/technical-planning.md#readme) | How to write technical plans |
 | [Vendor Evaluations](/playbooks/vendor-evaluations.md#readme) | How to evaluate 3rd party vendors |
 <!-- end_toc -->
 <!-- prettier-ignore-end -->

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -47,7 +47,8 @@ practice should be incorporated, submit a PR!
 | [How to run a Knowledge Share](/playbooks/running-knowledge-share.md#readme) | How to handle the people process for Knowledge Shares |
 | [System Criticality](/playbooks/system-criticality.md#readme) | A framework for treating systems differently according to how critical they are |
 | [Taming notifications](/playbooks/taming-notifications.md#readme) | How to set up notifications so that they leave you alone outside of working hours |
-| [Technology choices](/playbooks/technology-choices.md#readme) | How to make technology decisions at Artsy |
+| [Technology choices](/playbooks/technology-choices.md#readme) | How to make new technology decisions at Artsy |
+| [Technical planning](/playbooks/technical-planning.md#readme) | How to write technical plans at Artsy |
 | [Vendor Evaluations](/playbooks/vendor-evaluations.md#readme) | How to evaluate 3rd party vendors |
 <!-- end_toc -->
 <!-- prettier-ignore-end -->

--- a/playbooks/technical-planning.md
+++ b/playbooks/technical-planning.md
@@ -11,6 +11,7 @@ Technical planning is a crucial part of our engineering process. Writing tech pl
 - Communicate and collaborate effectively on technical decisions in an async manner.
 - Think through problems in a way that allows developers to practice technical decision-making & grow.
 - Get feedback early on in the development process, to avoid costly U-turns further down the line.
+- Refine and shape product requirements.
 
 Developers should use their judgment when deciding whether or not to write a tech plan, but we recommend them when planning:
 1. Technical design for medium to large features
@@ -18,9 +19,9 @@ Developers should use their judgment when deciding whether or not to write a tec
 1. Changes affecting other teams' products or engineers' workflows
 1. New integrations or services
 
-If the feature you're working on follows our best-practices and doesn't require technical decisions larger than what would fit in a single PR, it's OK to skip.
+If the feature you're working on follows our established patterns and doesn't require technical decisions larger than what would fit in a single PR, it's OK to skip.
 
-If you're working on a small feature or it doesn't fit the criteria above but you still want to write one, that's fine! Feel free to keep it small.
+If you're working on a small feature or it doesn't fit the criteria above but you still want to write one, that's fine! Feel free to keep it small. If you choose not to create a tech plan, make sure to document decisions (even small ones) as part of PR descriptions.
 
 ## Tech Plans vs. Product Briefs
 Technical plans discuss and propose a technical implementation, while product briefs should govern the design, user experience, and business requirements of a feature. We recommend linking to an associated product brief for context, but product and requirement decisions should live on the product brief, not on the tech plan.
@@ -33,17 +34,19 @@ If product-related feedback comes up while the tech plan is being reviewed, that
 ### Draft
 A tech plan in this state is a work in progress.
 
-### Proposed
+### Open for Feedback
 A tech plan in this state is officially open for feedback. Anyone should feel free to look at Proposed tech plans and leave their thoughts.
 
-### Accepted
-A tech plan in this state has been approved by all associated stakeholders. At this stage, it can be implemented or deprioritized.
+### Implementing
+A tech plan in this state has been approved by all associated reviewers and is being worked on.
+
+### Done
+A tech plan in this state has been implemented. Generally, tech plans can be put into this state at the same time that the associated product brief, if there is one, is moved to "Done".
 
 ### Closed
-A tech plan in this state has either been rejected outright (i.e. it was proposing a new technology that the team decides not to adopt) or otherwise abandoned before it was able to be formally accepted.
+A tech plan in this state has either been rejected outright (i.e. it was proposing a new technology that the team decides not to adopt), or otherwise abandoned before it was able to be formally accepted.
 
-### Implemented
-A tech plan in this state has been implemented. Generally, tech plans can be put into this state at the same time that the associated product brief, if there is one, is moved to "Done".
+When closing a tech plan, include a description as to why it's been closed.
 
 ## Writing a tech plan
 We recommend following the template in Notion, but feel free to add or remove sections. Be as clear, concise, and organized as possible when writing so that it is easy for others to understand and leave quality feedback.
@@ -52,16 +55,18 @@ If the technical plan involves a contentious or impactful technical decision, we
 
 As with the tech planning process itself, creating decision matrices benefits from [collaboration and feedback](https://review.firstround.com/this-matrix-helps-growing-teams-make-great-decisions).
 
-## Stakeholders
-Stakeholders represent the list of people from whom you require tech plan approval. Think of this as similar to the "Reviewers" field on Github PRs. As the author of the tech plan, you are responsible for choosing appropriate stakeholders to arrive at the best technical approach.
+## Reviewers
+Reviewers represent the list of people from whom you require tech plan approval. Think of this as similar to the Reviewers field on Github PRs. As the author of the tech plan, you are responsible for choosing appropriate reviewers to arrive at the best technical approach.
 
-Some guidelines for choosing stakeholders:
-- Aim for ~3-5 stakeholders.
-- Stakeholders should be from the engineering team, given the tech plan is focused on implementation decisions. Of course it's great to share and collaborate outside of engineering, but other team members need not be on this list.
-- Choose stakeholders whose expertise is important for ensuring the best decision is made. If the change affects another team's domain, include someone from that team. Consider including your team's tech lead as well as relevant staff engineers.
+Some guidelines for choosing reviewers:
+- Aim for ~3-5 reviewers.
+- Reviewers should be from the engineering team, given the tech plan is focused on implementation decisions. Of course it's great to share and collaborate outside of engineering, but other team members need not be on this list.
+- Choose reviewers whose expertise is important for ensuring the best decision is made. If the change affects another team's domain, include someone from that team. Consider including your team's tech lead as well as relevant staff engineers.
+
+If you are not initially included as a reviewer but have blocking feedback, you may add yourself as a reviewer.
 
 ## Receiving Feedback
-Since all developers are invited to participate on a tech plan and leave feedback, setting clear expectations on the tech plan's timeline can help ensure this process is smooth. We recommend filling out the Feedback requested by field.
+Since all developers are invited to participate on a tech plan and leave feedback, setting clear expectations on the tech plan's timeline can help ensure this process is smooth. We recommend filling out the "Feedback requested by" date field.
 
 If there is someone that you explicitly want feedback from, include them in the Stakeholders section (and don't hesitate to remind them directly, Notion notifications are easily lost).
 
@@ -75,7 +80,8 @@ If you have questions about or significant feedback on the overall direction of 
 ## Reviewing and Approving a Tech Plan
 Stakeholders are required to formally review the tech plan (also in a similar manner as Github PRs) by marking the plan with the appropriate review status:
 - **Approved** means that you are OK with the direction proposed by the plan.
-- **Rejected** means that you are not OK with the proposed direction.
-- **Request changes** means that you would be OK with the proposed direction, provided some changes (that you clarify in the Comments section) are addressed.
+- **Request changes** means that you require some changes (that you clarify in the Comments section) before accepting the plan.
 
 Based on these review statuses, the tech plan author can make changes and ask for a subsequent review.
+
+While the tech plan writer is responsible for the ultimate decision on whether a tech plan moves into the next state, they are expected to take feedback from reviewers seriously and address requested changes.

--- a/playbooks/technical-planning.md
+++ b/playbooks/technical-planning.md
@@ -1,0 +1,81 @@
+---
+title: Technology choices
+description: How to write technical plans at Artsy
+---
+
+# Technical planning
+
+Technical planning is a crucial part of our engineering process. Writing tech plans helps us:
+- Keep track of technical decisions that we've made, and the associated rationale.
+- Streamline a team's development of a feature and align within and across teams.
+- Communicate and collaborate effectively on technical decisions in an async manner.
+- Think through problems in a way that allows developers to practice technical decision-making & grow.
+- Get feedback early on in the development process, to avoid costly U-turns further down the line.
+
+Developers should use their judgment when deciding whether or not to write a tech plan, but we recommend them when planning:
+1. Technical design for medium to large features
+1. Architectural changes or new design patterns
+1. Changes affecting other teams' products or engineers' workflows
+1. New integrations or services
+
+If the feature you're working on follows our best-practices and doesn't require technical decisions larger than what would fit in a single PR, it's OK to skip.
+
+If you're working on a small feature or it doesn't fit the criteria above but you still want to write one, that's fine! Feel free to keep it small.
+
+## Tech Plans vs. Product Briefs
+Technical plans discuss and propose a technical implementation, while product briefs should govern the design, user experience, and business requirements of a feature. We recommend linking to an associated product brief for context, but product and requirement decisions should live on the product brief, not on the tech plan.
+
+It's natural to discover new product implications through the tech planning process. If this happens, make sure those discussions are routed to the product brief for clarity.
+
+If product-related feedback comes up while the tech plan is being reviewed, that is often a sign that there is more to discuss and debate at the product brief-level. If you are authoring a tech plan and this happens, it is recommended that you bring the conversation immediately to the associated PM(s). Once the question or feedback is addressed, the tech planning can continue.
+
+## Tech Plan States
+### Draft
+A tech plan in this state is a work in progress.
+
+### Proposed
+A tech plan in this state is officially open for feedback. Anyone should feel free to look at Proposed tech plans and leave their thoughts.
+
+### Accepted
+A tech plan in this state has been approved by all associated stakeholders. At this stage, it can be implemented or deprioritized.
+
+### Closed
+A tech plan in this state has either been rejected outright (i.e. it was proposing a new technology that the team decides not to adopt) or otherwise abandoned before it was able to be formally accepted.
+
+### Implemented
+A tech plan in this state has been implemented. Generally, tech plans can be put into this state at the same time that the associated product brief, if there is one, is moved to "Done".
+
+## Writing a tech plan
+We recommend following the template in Notion, but feel free to add or remove sections. Be as clear, concise, and organized as possible when writing so that it is easy for others to understand and leave quality feedback.
+
+If the technical plan involves a contentious or impactful technical decision, we recommend creating a separate, linked, document to capture the alternatives considered ([example here](https://www.notion.so/artsy/d17290484e6b40ac9e871eb7070dd3e8?v=81f6f3bf425b43e48fadd3c36adc2e09)). This allows the tech plan to focus on the chosen option.
+
+As with the tech planning process itself, creating decision matrices benefits from [collaboration and feedback](https://review.firstround.com/this-matrix-helps-growing-teams-make-great-decisions).
+
+## Stakeholders
+Stakeholders represent the list of people from whom you require tech plan approval. Think of this as similar to the "Reviewers" field on Github PRs. As the author of the tech plan, you are responsible for choosing appropriate stakeholders to arrive at the best technical approach.
+
+Some guidelines for choosing stakeholders:
+- Aim for ~3-5 stakeholders.
+- Stakeholders should be from the engineering team, given the tech plan is focused on implementation decisions. Of course it's great to share and collaborate outside of engineering, but other team members need not be on this list.
+- Choose stakeholders whose expertise is important for ensuring the best decision is made. If the change affects another team's domain, include someone from that team. Consider including your team's tech lead as well as relevant staff engineers.
+
+## Receiving Feedback
+Since all developers are invited to participate on a tech plan and leave feedback, setting clear expectations on the tech plan's timeline can help ensure this process is smooth. We recommend filling out the Feedback requested by field.
+
+If there is someone that you explicitly want feedback from, include them in the Stakeholders section (and don't hesitate to remind them directly, Notion notifications are easily lost).
+
+Significant tech plans benefit from a synchronous review in a practice meeting. If there is not a practice meeting that works for your timeline, schedule something ad-hoc. Make sure to mention the tech plan in our weekly engineering standup to invite broader feedback.
+
+## Giving Tech Plan Feedback
+Feedback is expected and encouraged. Similar to leaving PR comments, please distinguish between blocking and non-blocking feedback so that your intent is clear.
+
+If you have questions about or significant feedback on the overall direction of the tech plan, we recommend asking the tech plan author to hop on a quick call to discuss.
+
+## Reviewing and Approving a Tech Plan
+Stakeholders are required to formally review the tech plan (also in a similar manner as Github PRs) by marking the plan with the appropriate review status:
+- **Approved** means that you are OK with the direction proposed by the plan.
+- **Rejected** means that you are not OK with the proposed direction.
+- **Request changes** means that you would be OK with the proposed direction, provided some changes (that you clarify in the Comments section) are addressed.
+
+Based on these review statuses, the tech plan author can make changes and ask for a subsequent review.

--- a/playbooks/technical-planning.md
+++ b/playbooks/technical-planning.md
@@ -65,7 +65,7 @@ Since all developers are invited to participate on a tech plan and leave feedbac
 
 If there is someone that you explicitly want feedback from, include them in the Stakeholders section (and don't hesitate to remind them directly, Notion notifications are easily lost).
 
-Significant tech plans benefit from a synchronous review in a practice meeting. If there is not a practice meeting that works for your timeline, schedule something ad-hoc. Make sure to mention the tech plan in our weekly engineering standup to invite broader feedback.
+Significant tech plans benefit from a synchronous review in a practice meeting. If there is not a practice meeting that works for your timeline, schedule something ad-hoc. Make sure to mention the tech plan in [our weekly engineering standup](https://github.com/artsy/README/blob/main/events/open-standup.md) to invite broader feedback.
 
 ## Giving Tech Plan Feedback
 Feedback is expected and encouraged. Similar to leaving PR comments, please distinguish between blocking and non-blocking feedback so that your intent is clear.

--- a/playbooks/technology-choices.md
+++ b/playbooks/technology-choices.md
@@ -33,27 +33,7 @@ Artsy's current choices can be [edited in raw form here](/playbooks/technology_r
 
 ## Technical Plans and Review
 
-When new systems, technologies, or architectures are considered, we document their rationale and gather feedback in
-a [technical plan document](https://github.com/artsy/README/issues/245)
-([examples](https://www.notion.so/artsy/Technical-Plans-f94b206fcec54cee8b4d864e67d5b70f)🔒). This document states
-the problem, surfaces questions, and lists possible approaches. Feedback should be invited from relevant experts
-within the team _and beyond_, because these circumstances are rarely unique, and the choices tend to outlast
-specific projects or even teams. [Weekly engineering stand-up](/events/open-standup.md) is a good opportunity to
-request feedback from the wider team.
-
-Once initial feedback and updates are reflected on the technical plan document, a face-to-face _technical review_
-discussion is an efficient way to resolve open issues and confirm next steps. This discussion can be scheduled for
-standing practice meetings, team knowledge-shares, or ad hoc if necessary. In the review, the relevant teams'
-engineers are responsible for recommending a path forward. (If there isn't clear agreement, you may want to revisit
-the problem and rationale.) The teams' technical leads and someone from engineering leadership (Dir/VP) should be
-stakeholders on the plan and invited to the review discussion as well.
-
-When a plan depends on technology that isn't in the "adopt" category, it's worth special care to:
-
-- justify the suitability of the choice
-- document the goals of the "trial"
-- limit any production risk or organizational burden
-- if successful, plan to deprecate competing or overlapping technologies
+See [this document](/playbooks/technical-planning.md) for more information on technical planning.
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
# Proposal
This RFC proposes:
- Adding a new document describing our technical planning process. This will be linked to from the existing `technology_choices` document, but since tech plans are about more than just adding new technologies, we feel it warrants its own page.
- Clarification to all steps of our current tech planning process, much of which is implicit. We expect these steps to change over time. This clarification touches topics such as:
    - What is a tech plan
    - When to write one
    - How to write one
    - What the possible states are (and how to advance between them)
    - How to choose stakeholders
    - How to provide feedback and approve a tech plan
- Consolidating a few fields on the template:
    - `Contributors` and `Champions` will be removed, replaced by a single field “Author(s)” so that it’s clear who to contact about a given tech plan. We expect this to be filled by 1-2 people.
    - Removing the `DRI` and `Decider` fields. We found these fields are used differently by different team members and add confusion. We instead propose an updated “Stakeholders” section which should cover this need.
- Adding a new state: Implemented, to clarify the difference between a tech plan that was accepted (but then deprioritized) vs. one whose changes exist in code.
- Expanding the Stakeholders section to include different review states: Approved, Rejected, and Changes Requested (with a comment field) in order to clarify the review process.

# Reasoning
As our team has grown and more tech plans have been written, it’s become clear that some clarification of our existing process would help streamline the process. The lack of clarity was confirmed in a recent survey we conducted with the engineering team. While most respondents appreciated the open nature of our tech planning process and how widely it has been adopted, there were a lot of questions, particularly around the states and approval process.

The goal of this RFC is to make our tech planning process clearer. By writing down what our existing process is, it should also be easier to update via similar RFCs to this one.

# How is this RFC resolved?
If there is a strong majority of 👍 compared to 👎 and at least 20 votes, this RFC will be resolved.

There are two parts to this RFC resolution:
- Merging in this PR (taking comments into account), which adds the new document and links to it from a few places in README.
- Updating the tech plan template based on the proposal above.
