### PR TITLE
feat: clarify significant staging issues should be treated as incidents

### DIFF
--- a/playbooks/incident-handling.md
+++ b/playbooks/incident-handling.md
@@ -315,6 +315,8 @@ Many people follow the #incidents channel closely, so avoid noise by keeping dis
   <!-- TODO: define how to apply priority levels more consistently -->
 - Take your best guess at the other information; it can always be edited later.
 
+Issues isolated to staging (i.e., issues that do not have have an observable impact on production) resulting in major workflow disruptions should also be treated as incidents. When communicating a staging incident, it should be made clear that there is no preceived impact on production to avoid creating confusion for the team members following the incident.
+
 2. **Create a Slack channel** dedicated to the incident's technical resolution
 
 - Follow the **Create Slack channel** link from the OpsGenie incident page and create a `#inc-*` channel named with


### PR DESCRIPTION
This PR is a follow-up to incident [161](https://artsy.slack.com/archives/C04BPTCCZ9N). In the review discussion, we agreed that it makes sense that incidents affecting staging, but not production, still go through the same process. This just adds instruction to that effect in the incident playbook. 

If everyone is on board I'll share the change in #dev, as a follow-up. 

Note: we had discussed in the call that we keep the discussion to #dev, and not use #incidents when it just affects staging. While finalizing the postmortem, It seemed overly confusing to have two different processes. So, instead, I just added a line here to emphasize the scope of the incident should be communicated. 

Happy to change course if anyone feels this was a bad call. 

[Platform-4787]