### PR TITLE
doc: Update documentation playbook to reflect transition from Potential to Notion

### DIFF
--- a/playbooks/documentation.md
+++ b/playbooks/documentation.md
@@ -73,13 +73,14 @@ content such as:
 - team procedures and playbooks
 - other public resources that are not repo-specific
 
-The private [artsy/potential](https://github.com/artsy/potential) repo supplements artsy/README with resources such
-as:
+[Notion](https://www.notion.so/artsy/About-Artsy-83c4c35f2e554663927df7fccc3aca70)🔒 is our preferred location for
+internal documentation, because it is a company-wide default. It includes:
 
-- documentation and diagrams of internal architecture
-- security bounty program procedures
-- playbooks for handling common on-call incidents (see [the wiki](https://github.com/artsy/potential/wiki))
-- any other content that should be private according to the criteria above
+- Documentation and diagrams of
+  [internal architecture](https://www.notion.so/artsy/Platform-Architecture-ad1363b26ea8422db0df08e7c8253677)🔒
+- [Security bounty program procedures](https://www.notion.so/artsy/Security-Bounty-Program-Playbook-0071e3292a194f23b6a8ae593a08d3f3)🔒
+- [Playbooks for handling common on-call incidents](https://www.notion.so/artsy/Engineering-Playbooks-b655fe54c1ce4b35af342c9ed9a489ae)🔒
+- Any other content that should be private according to the criteria above
 
 ## Engineering blog
 


### PR DESCRIPTION
https://github.com/artsy/README/issues/492 prompted me to take a look at our existing documentation playbook covering some of the same topics. I had failed to update it when we decided that _Notion_ would be a preferable location for internal documentation instead of the Potential repo.