### PR TITLE
fix: add Python as it has been in use in various repos.

### DIFF
--- a/playbooks/technology_radar/artsy-tech-radar.csv
+++ b/playbooks/technology_radar/artsy-tech-radar.csv
@@ -2,7 +2,7 @@ name,ring,quadrant,isNew,description
 GraphQL Stitching,hold,techniques,TRUE,"We prefer to connect to upstream REST APIs instead of GraphQL APIs."
 GraphQL,adopt,languages & frameworks,TRUE,"Appreciated for its flexibility and efficiency for clients."
 JSON,adopt,languages & frameworks,FALSE,"We prefer JSON over most other data formats for its self-describing properties."
-Python,adopt,languages & frameworks,FALSE,
+Python,adopt,languages & frameworks,FALSE,"For ETL, Analytics and ML workloads we use Python as a data engineering standard."
 Rails,adopt,languages & frameworks,FALSE,
 React Native,adopt,languages & frameworks,FALSE,"New iOS work should use React Native. See also Objective-C."
 React.js,adopt,languages & frameworks,FALSE,

--- a/playbooks/technology_radar/artsy-tech-radar.csv
+++ b/playbooks/technology_radar/artsy-tech-radar.csv
@@ -2,6 +2,7 @@ name,ring,quadrant,isNew,description
 GraphQL Stitching,hold,techniques,TRUE,"We prefer to connect to upstream REST APIs instead of GraphQL APIs."
 GraphQL,adopt,languages & frameworks,TRUE,"Appreciated for its flexibility and efficiency for clients."
 JSON,adopt,languages & frameworks,FALSE,"We prefer JSON over most other data formats for its self-describing properties."
+Python,adopt,languages & frameworks,FALSE,
 Rails,adopt,languages & frameworks,FALSE,
 React Native,adopt,languages & frameworks,FALSE,"New iOS work should use React Native. See also Objective-C."
 React.js,adopt,languages & frameworks,FALSE,


### PR DESCRIPTION
In recent discussions around an [Opstools PR](https://github.com/artsy/opstools/pull/12), we noticed that the Tech Radar has no entry for Python. It seems we should add such an entry, because there are significant [repositories with Python code](https://github.com/orgs/artsy/repositories?language=python&q=&sort=&type=all), Hokusai/Motion/Zenith being the main ones.

The `description` field for the entry is left blank, to be filled in based on discussion in this PR, therefore, the PR is tagged `Draft`.