### PR TITLE
doc: clarify ruby's adopt status

### DIFF
--- a/playbooks/technology_radar/artsy-tech-radar.csv
+++ b/playbooks/technology_radar/artsy-tech-radar.csv
@@ -6,7 +6,7 @@ Rails,adopt,languages & frameworks,FALSE,
 React Native,adopt,languages & frameworks,FALSE,"New iOS work should use React Native. See also Objective-C."
 React.js,adopt,languages & frameworks,FALSE,
 Relay,adopt,languages & frameworks,FALSE,
-Ruby,adopt,languages & frameworks,FALSE,
+Ruby,adopt,languages & frameworks,FALSE,"Especially for data-backed APIs and services"
 Spark,adopt,languages & frameworks,FALSE,"Artsy manages a Spark cluster and patterns exist to load data from the main Gravity database as well as other systems, distribute processing among all of the available nodes, and interact with S3, HDFS, or Redshift. See the Cinder repo."
 SQL,adopt,languages & frameworks,FALSE,
 styled-components,adopt,languages & frameworks,FALSE,


### PR DESCRIPTION
Inspired by https://github.com/artsy/README/pull/501, let's clarify ruby's "adopt" status, especially for data-backed APIs and services.

We have many ruby back-ends and significant built-up experience maintaining and evolving them. (The only exceptions I can think of are Positron, Causality, and APRD, which are unmaintained or deeply out-of-favor.) It should be the default option for any new back-end needs.