### PR TITLE
RFC: make `asdf` the default version manager

### DIFF
--- a/playbooks/version-managers.md
+++ b/playbooks/version-managers.md
@@ -1,0 +1,38 @@
+---
+title: Version managers
+description: What we use to manager tool versions.
+---
+
+
+## asdf by default
+
+We use [asdf] to manage our tool versions. asdf can handle most tools using plugins, here are some:
+- [nodejs](https://github.com/asdf-vm/asdf-nodejs)
+- [ruby](https://github.com/asdf-vm/asdf-ruby)
+- [python](https://github.com/asdf-community/asdf-python)
+- [java](https://github.com/halcyon/asdf-java)
+- [yarn](https://github.com/twuni/asdf-yarn)
+
+It uses other version managers under the hood, but it keeps everything clean and consistent.
+
+## Differences
+
+It uses just one file to set the versions, like [in eigen](https://github.com/artsy/eigen/blob/main/.tool-versions).
+We can also use the existing version files like `.nvmrc` and `.ruby-version` to set the versions. asdf has a `legacy_version_file` config option that makes it look at these files instead of `.tool-versions`, but keeping the old ones would make it easy for people that don't want to use asdf to still get the right versions. (Though asdf is actually the best version manager there is.)
+
+## Installation
+
+Installation is documented [here](https://asdf-vm.com/guide/getting-started.html#_3-install-asdf). Basically `brew install asdf`, and adding `. $(brew --prefix asdf)/libexec/asdf.sh` to your shell's rc file.
+
+## Usage
+
+Here's some quick help:
+- To install the right versions: `asdf install`.
+- To set a new local version (only for the repo you're in): `asdf set nodejs 12.16.1`.
+- To set a new global version: `asdf global nodejs 12.16.1`.
+- To see what versions are available: `asdf list-all nodejs`.
+- To see what versions are installed: `asdf list nodejs`.
+- To see what versions are set: `asdf current`.
+
+
+[asdf]: https://github.com/asdf-vm/asdf


### PR DESCRIPTION
## Proposal

Use asdf as our default version manager. It makes it easy to handle multiple tools and their versions.

## Reasoning

Many people at artsy have started using asdf. We have also added it to eigen and energy and it has been great. It would be great to extend the usage to all our repos, so we have more consistency. Some people might still want to use their version manager of choice. That's fine, we can keep all the dotfiles for both asdf and other version managers. asdf has made it easy to work with multiple tools, like node, ruby, java, and we even had it for python at some point with detect-secrets. It makes this easy, and it behaves well and consistent for all tools. nvm works differently from rbenv for example. asdf is working the same for all tools, and only requires one change in the shell's rc file.

## How is this RFC resolved?

Adding `.tool-versions` in all our repos, and later changing our setup scripts to use asdf.
