### PR TITLE
RFC: PR titles (conv-commits modification)

### DIFF
--- a/playbooks/PR-titles.md
+++ b/playbooks/PR-titles.md
@@ -1,0 +1,26 @@
+---
+title: Human conventional commits
+description: Use conventional commit, but better.
+---
+
+We use a modified version of [conventional commits] for our PR titles:
+- `HOTFIX`: If an urgent fix is required.
+- `feat`: A new feature.
+- `fix`: A bug fix.
+- `docs`: Documentation only changes.
+- `perf`: A code change that improves performance.
+- `test`: Adding missing tests or correcting existing tests.
+- `format`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc, linting).
+- `revert`: Revert something.
+- `update` or `upgrade`: Update dependencies or pods or other related things.
+- `refactor`: A code change that keeps functionality mostly the same.
+- `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm).
+- `uxui`: changes that affect how something looks or how the user experiences it.
+- `cleanup`: When the main change is removing code, old or unused.
+- `other`: catch-all, and once we have had a bunch of those, we can possibly make a new category.
+
+We have the [peril check] checking this.
+
+
+[conventional commits]: https://www.conventionalcommits.org/en/v1.0.0/#specification
+[peril check]: https://github.com/artsy/peril-settings/blob/fcad894359533dbc777ea17ee536bd9e7d44a756/org/allPRs.ts#L225


### PR DESCRIPTION


## Proposal

After [my comment here](https://artsy.slack.com/archives/C02NAJ2CGLW/p1652707008240989?thread_ts=1652704713.254419&cid=C02NAJ2CGLW) I promised I will ues the regular conv commits until I make an RFC. Here is that RFC.

And here is my modified list of [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) for our PR titles:
- `HOTFIX`: If an urgent fix is required.
- `feat`: A new feature.
- `fix`: A bug fix.
- `docs`: Documentation only changes.
- `perf`: A code change that improves performance.
- `test`: Adding missing tests or correcting existing tests.
- `format`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc, linting).
- `revert`: Revert something.
- `update` or `upgrade`: Update dependencies or pods or other related things.
- `refactor`: A code change that keeps functionality mostly the same.
- `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm).
- `uxui`: changes that affect how something looks or how the user experiences it.
- `cleanup`: When the main change is removing code, old or unused.
- `other`: catch-all, and once we have had a bunch of those, we can possibly make a new category.

## Reasoning

It all started with me hating attaching the word `chore` on any of my work. I refused to use it, and I have only used it begrudgingly for some PRs after my promise, and on very very few PRs that I would actually characterize as chores.

I then decided to do an investigation a few months ago. I took 300 commits from eigen, and checked their type. In these 300 commits we had:
- 20 chore
- 7 enhancement
- 50 feat
- 85 fix
- 1 format
- 9 refactor
- rest were merge commits, or uncharacterized commits.

So my thoughts after this were:
- `fix`es and `feat`s are a lot, but that makes sense. We add new stuff, and we fix stuff. But we probably can be better at characterizing these, so adding labels like `uxui` might make PR titles slightly more specific.
- `chore` is a bit of a catch-all, and I think we can do better. We can use `cleanup` for removing code, and `update` for updating dependencies. We can also use `other` for things that don't fit in any of the other categories, while valuing our work a bit more, and not just calling it a chore.

This new list was suggested [here](https://artsy.slack.com/archives/C2TQ4PT8R/p1648168385012589?thread_ts=1648141250.236779&cid=C2TQ4PT8R). The main differences are:
- this list should not be limited to this, but it should be fine for like 95% of commits/PRs.
- `update`/`upgrade`, they are needed, this work is not a chore.
- `chore` can go live somewhere else, where bad words go to die. I replaced it with `other`. Better word, less negative, same length. But we can allow `chore` if someone really found some work to be a chore. It should not be the catch-all though.
- `uxui`, I don't know how this is missing from other lists. This is needed.

## Additional Context

Lengthy discussions on slack:
- https://artsy.slack.com/archives/C02NAJ2CGLW/p1652704713254419
- https://artsy.slack.com/archives/C2TQ4PT8R/p1648141250236779

## How is this RFC resolved?

Change the [peril check](https://github.com/artsy/peril-settings/blob/fcad894359533dbc777ea17ee536bd9e7d44a756/org/allPRs.ts#L225). Change the graphs generated by the velocity team to include the new labels.
