### PR TITLE
docs: update guidance on pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,19 @@ We split this repo out into different sections, each one has a summary of what's
 
 <!-- prettier-ignore-start -->
 <!-- start_toc -->
-| Section                                                  |                                                           |
-|----------------------------------------------------------|-----------------------------------------------------------|
-| [Careers at Artsy](/careers#readme)                      | How do we grow people                                     |
-| [Conference Notes](/conference-notes#readme)             | Artsy Engineers' notes from attending conferences.        |
-| [Engineering Culture](/culture#readme)                   | What makes Artsy Engineering tick?                        |
-| [Events at Artsy](/events#readme)                        | Documentation on regularly occurring events and meetings. |
-| [Hiring at Artsy](/hiring#readme)                        | How do we hire people                                     |
-| [Onboarding Notes for New Engineers](/onboarding#readme) | Your first steps to being productive                      |
-| [Playbooks](/playbooks#readme)                           | Tips, procedures, and best practices                      |
-| [Engineering Practices](/practices#readme)               | How do we handle cross-functional concerns.               |
-| [Engineering Recommendations](/resources#readme)         | Collections of further reading.                           |
+| Section |  |
+|--|--|
+| [[TODO] Add a summary.json to RFCs](/RFCs) | [TODO] |
+| [[TODO] Add a summary.json to _templates](/_templates) | [TODO] |
+| [Careers at Artsy](/careers#readme) | How do we grow people |
+| [Conference Notes](/conference-notes#readme) | Artsy Engineers' notes from attending conferences. |
+| [Engineering Culture](/culture#readme) | What makes Artsy Engineering tick? |
+| [Events at Artsy](/events#readme) | Documentation on regularly occurring events and meetings. |
+| [Hiring at Artsy](/hiring#readme) | How do we hire people |
+| [Onboarding Notes for New Engineers](/onboarding#readme) | Your first steps to being productive |
+| [Playbooks](/playbooks#readme) | Tips, procedures, and best practices |
+| [Engineering Practices](/practices#readme) | How do we handle cross-functional concerns. |
+| [Engineering Recommendations](/resources#readme) | Collections of further reading. |
 <!-- end_toc -->
 <!-- prettier-ignore-end -->
 

--- a/RFCs/README.md
+++ b/RFCs/README.md
@@ -1,10 +1,25 @@
 ### How we handle RFCs at Artsy
 
-RFCs are an important part of how we evolve as an engineering organisation. Any time someone wants to introduce a change to our existing processes, or concretely define a process that was previously unspoken, they create an RFC. 
+RFCs are an important part of how we evolve as an engineering organisation. Any time someone wants to introduce a
+change to our existing processes, or concretely define a process that was previously unspoken, they create an RFC.
 
-The RFC is a pull request that creates a new markdown document in this directory, describing the change or definition. This document is then discussed within the PR and a decision is reached on whether to accept or reject the proposal. If the proposal is accepted, the PR is merged, leaving us with a permanent record of the accepted proposal.
+The RFC is a pull request that creates a new markdown document in this directory, describing the change or
+definition. This document is then discussed within the PR and a decision is reached on whether to accept or reject
+the proposal. If the proposal is accepted, the PR is merged, leaving us with a permanent record of the accepted
+proposal.
 
 These documents can of course be changed at a later date via a new RFC PR.
 
-For a more detailed description of the process, take a look at our [RFC Playbook](https://github.com/artsy/README/blob/main/playbooks/rfcs.md).
+For a more detailed description of the process, take a look at our
+[RFC Playbook](https://github.com/artsy/README/blob/main/playbooks/rfcs.md).
 
+<!-- prettier-ignore-start -->
+<!-- start_toc -->
+
+| Doc                                                                                                                     | Overview                                                                         |
+| ----------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| [[TODO] add title via yml front-matter to RFCs/on-call-incident-review.md](/RFCs/on-call-incident-review.md#readme)     | [TODO] add description via yml front-matter to RFCs/on-call-incident-review.md   |
+| [[TODO] add title via yml front-matter to RFCs/use-prs-instead-of-issues.md](/RFCs/use-prs-instead-of-issues.md#readme) | [TODO] add description via yml front-matter to RFCs/use-prs-instead-of-issues.md |
+
+<!-- end_toc -->
+<!-- prettier-ignore-end -->undefined

--- a/_templates/README.md
+++ b/_templates/README.md
@@ -1,0 +1,12 @@
+### [TODO]
+
+<!-- prettier-ignore-start -->
+<!-- start_toc -->
+| Doc | Overview |
+|--|--|
+| [[TODO] add title via yml front-matter to _templates/dependency-rfc.md](/_templates/dependency-rfc.md#readme) | [TODO] add description via yml front-matter to _templates/dependency-rfc.md |
+| [[TODO] add title via yml front-matter to _templates/rfc.md](/_templates/rfc.md#readme) | [TODO] add description via yml front-matter to _templates/rfc.md |
+<!-- end_toc -->
+<!-- prettier-ignore-end -->
+
+[TODO]

--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -18,42 +18,39 @@ practice should be incorporated, submit a PR!
 
 <!-- prettier-ignore-start -->
 <!-- start_toc -->
-### Cultural
 | Doc | Overview |
 |--|--|
-| [Engineer workflow](/playbooks/engineer-workflow.md#readme) | How we work together |
-| [Request for Comments [RFC]](/playbooks/rfcs.md) | How do we make a Request for Comments? |
-| [Documentation](/playbooks/documentation.md#readme) | How and where to document or share content |
-| [Future Friday](/playbooks/future-friday.md#readme) | What is Future Friday? |
-| [Conferences](/playbooks/conferences.md#readme) | Attending or speaking at a conference |
-| [How to give a good Informational](/playbooks/informationals.md#readme) | What are the steps needed to give someone a great experience. |
-| [The Practice Playbook](/playbooks/practices.md#readme) | How do you run a practice at Artsy? |
-| [Retrospectives](/playbooks/retrospectives.md#readme) | The why and how for running a retrospective |
-| [Knowledge Shares](/playbooks/running-knowledge-share.md#readme) | How to handle the people process for Knowledge Shares |
-| [Taming notifications](/playbooks/taming-notifications.md#readme) | How to set up notifications so that they leave you alone outside of working hours |
-| [Technology choices](/playbooks/technology-choices.md#readme) | How to make technology decisions at Artsy |
-| [Technical planning](/playbooks/technical-planning.md#readme) | How to write technical plans |
-| [Vendor Evaluations](/playbooks/vendor-evaluations.md#readme) | How to evaluate 3rd party vendors |
-### Technical
-| Doc | Overview |
-|--|--|
-| [Development environments](/playbooks/development-environments.md#readme) | Getting set up to work on new projects |
 | [Cloudflare](/playbooks/cloudflare.md#readme) | Working with Cloudflare |
+| [Conferences](/playbooks/conferences.md#readme) | Attending or speaking at a conference |
 | [Data Migrations](/playbooks/data-migrations.md#readme) | Preparing, reviewing and executing data migrations |
 | [Dependency Management Recommendations](/playbooks/dependencies.md#readme) | How do we want to handle new dependencies to our apps? |
 | [Deployments](/playbooks/deployments.md#readme) | How systems are deployed at Artsy |
+| [Development environments](/playbooks/development-environments.md#readme) | Getting set up to work on new projects |
+| [Documentation](/playbooks/documentation.md#readme) | How and where to document or share content |
+| [Engineer workflow](/playbooks/engineer-workflow.md#readme) | How we work together |
 | [Extracting Services](/playbooks/extracting-services.md#readme) | When and why to consider extracting or decoupling systems |
+| [Future Friday](/playbooks/future-friday.md#readme) | What is Future Friday? |
 | [GraphQL Schema Design](/playbooks/graphql-schema-design.md#readme) | What are our best practices for GraphQL Schema Design? |
 | [Hokusai](/playbooks/hokusai.md#readme) | a CLI to manage applications deployed to Kubernetes |
-| [Jira](/playbooks/jira.md#readme) | Working with Jira boards and tickets |
 | [Incident Handling](/playbooks/incident-handling.md#readme) | How engineers share on-call duties and provide urgent support |
+| [How to give a good Informational](/playbooks/informationals.md#readme) | What are the steps needed to give someone a great experience. |
+| [Jira](/playbooks/jira.md#readme) | Working with Jira boards and tickets |
 | [Kubernetes](/playbooks/kubernetes.md#readme) | Deploying containerized applications at Artsy |
 | [Migrating Postgres with Rubyrep](/playbooks/migrating-postgres-with-rubyrep.md#readme) | How to migrate a Postgres to a new instance using Rubyrep |
 | [Migrating Redis](/playbooks/migrating-redis.md#readme) | How to migrate data between Redis instances. |
 | [Migrating Sidekiq](/playbooks/migrating-sidekiq.md#readme) | How to migrate Sidekiq to a new Redis instance |
 | [Open-sourcing a project](/playbooks/open-sourcing.md#readme) | How to take a private repo and make it open-source |
+| [The Practice Playbook](/playbooks/practices.md#readme) | How do you run a practice at Artsy? |
 | [Renaming master branches to main](/playbooks/rename-master-to-main.md#readme) | a CLI to manage applications deployed to Kubernetes |
+| [How to run a retrospective](/playbooks/retrospectives.md#readme) | The why and how for running a retrospective |
+| [How to create an RFC at Artsy](/playbooks/rfcs.md#readme) | The steps needed to request cultural changes |
+| [How to run a Knowledge Share](/playbooks/running-knowledge-share.md#readme) | How to handle the people process for Knowledge Shares |
 | [System Criticality](/playbooks/system-criticality.md#readme) | A framework for treating systems differently according to how critical they are |
+| [Taming notifications](/playbooks/taming-notifications.md#readme) | How to set up notifications so that they leave you alone outside of working hours |
+| [Technology choices](/playbooks/technical-planning.md#readme) | How to write technical plans at Artsy |
+| [Technology choices](/playbooks/technology-choices.md#readme) | How to make technology decisions at Artsy |
+| [Vendor Evaluations](/playbooks/vendor-evaluations.md#readme) | How to evaluate 3rd party vendors |
+| [Version managers](/playbooks/version-managers.md#readme) | What we use to manager tool versions. |
 <!-- end_toc -->
 <!-- prettier-ignore-end -->
 

--- a/playbooks/engineer-workflow.md
+++ b/playbooks/engineer-workflow.md
@@ -162,9 +162,9 @@ We encourage you to assign your completed PRs to one of your reviewers in order 
 distribute responsibilities and understanding. However self-assigning is permissible when an author wants to retain
 control over merging, sequencing or follow-ups related to the PR.
 
-Assigning exactly one reviewer — no more and no less — helps ensure that there's no question about who is
-responsible. Once someone has been assigned to a PR, they should make a good faith effort to take one of the
-following actions within one business day:
+Designating exactly one person as assignee — no more and no less — helps ensure that there's no question about who
+is responsible. Once someone has been assigned to a PR, they should try to take one of the following actions within
+one business day:
 
 - Merge the PR if comfortable doing so and the criteria below are met,
 - Re-assign to the original author so that they can merge, or

--- a/playbooks/engineer-workflow.md
+++ b/playbooks/engineer-workflow.md
@@ -6,7 +6,6 @@ description: How we work together
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Working together](#working-together)
   - [Project Management](#project-management)
   - [Workflow](#workflow)
@@ -44,8 +43,8 @@ clone the repo, create a working branch from `main`, then push that branch back 
 working branches should be named by their creator like `<github_user_name>/<prefix>/<topic>`, even when a
 collaboration.
 
-Wait, what? What prefix? We use [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) prefixes in our
-PR titles, because by default, we squash our commits when merging a PR, and this means that the squashed commit
+Wait, what? What prefix? We use [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) prefixes in
+our PR titles, because by default, we squash our commits when merging a PR, and this means that the squashed commit
 automatically ends up using the Conventional Commit format. Using the prefix in your branch name is not essential,
 but it's, well, nice.
 
@@ -54,7 +53,12 @@ but it's, well, nice.
 > A well-crafted git commit message is the best way to communicate context about a change to fellow developers (and
 > indeed to [our] future selves). -[How to write a git commit message](https://chris.beams.io/posts/git-commit/)
 
-In support of this, Artsy engineering adopted [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) as its commit message convention (see RFC [Best Practices for Naming and Merging PRs](https://github.com/artsy/README/issues/327)). We encourage you to read the [spec](https://www.conventionalcommits.org/en/v1.0.0/#specification) for more detail but, in general, all commits should match the following format ([see examples](https://www.conventionalcommits.org/en/v1.0.0/#examples)):
+In support of this, Artsy engineering adopted
+[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) as its commit message convention
+(see RFC [Best Practices for Naming and Merging PRs](https://github.com/artsy/README/issues/327)). We encourage you
+to read the [spec](https://www.conventionalcommits.org/en/v1.0.0/#specification) for more detail but, in general,
+all commits should match the following format
+([see examples](https://www.conventionalcommits.org/en/v1.0.0/#examples)):
 
 ```
 <type>[optional scope]: <description>
@@ -64,8 +68,8 @@ In support of this, Artsy engineering adopted [Conventional Commits](https://www
 [optional footer(s)]
 ```
 
-Many Artsy engineers will include the Jira ticket id as the `scope`, which will automatically link the PR to the Jira ticket, though this is not required. A basic Artsy commit may look like:
-
+Many Artsy engineers will include the Jira ticket id as the `scope`, which will automatically link the PR to the
+Jira ticket, though this is not required. A basic Artsy commit may look like:
 
 ```bash
 # commit with type of 'feat' and 'description'
@@ -79,6 +83,7 @@ feat(onboarding): add user onboarding flow analytics tracking
 ```
 
 The two main `types` of commits are `fix` and `feat`, however, commits with the following `types` are allowed:
+
 - `build`
 - `chore`
 - `ci`
@@ -91,11 +96,20 @@ The two main `types` of commits are `fix` and `feat`, however, commits with the 
 - `style`
 - `test`
 
-**Engineers should use the `type` that best describes the commit**, but we believe the majority of work will fit within the `feat`, `fix` and (to a lesser extent) `refactor` types.
+**Engineers should use the `type` that best describes the commit**, but we believe the majority of work will fit
+within the `feat`, `fix` and (to a lesser extent) `refactor` types.
 
-In instances where a PR will be simply merged - as opposed to being squashed before being merged - we generally expect each individual commit within the PR to follow the Conventional Commit format. **However, a developer may choose to use a good but "*unconvenitonal*" commit messages within a PR instead if they feel it will result in a more precise commit history on the `main` branch** (relevent discussion in this [PR](https://github.com/artsy/README/pull/478)). The PR title should still use the Conventional Commit format (see the [Pull requests](#pull-requests) section).
+In instances where a PR will be simply merged - as opposed to being squashed before being merged - we generally
+expect each individual commit within the PR to follow the Conventional Commit format. **However, a developer may
+choose to use a good but "_unconvenitonal_" commit messages within a PR instead if they feel it will result in a
+more precise commit history on the `main` branch** (relevent discussion in this
+[PR](https://github.com/artsy/README/pull/478)). The PR title should still use the Conventional Commit format (see
+the [Pull requests](#pull-requests) section).
 
-An additional benefit of using Conventional Commits is that it allows us to track the ratio of new work (i.e., feature work) against rework (i.e., bug/regression fixes). We currently use this ratio as one measure of code quality. **Importantly, this means that consistent commit messages and type accuracy supports meaningful metrics**. The ratio of feature to rework can be viewed [here](https://artsy.net/rework-metric).
+An additional benefit of using Conventional Commits is that it allows us to track the ratio of new work (i.e.,
+feature work) against rework (i.e., bug/regression fixes). We currently use this ratio as one measure of code
+quality. **Importantly, this means that consistent commit messages and type accuracy supports meaningful metrics**.
+The ratio of feature to rework can be viewed [here](https://artsy.net/rework-metric).
 
 ### Pull requests
 
@@ -117,10 +131,10 @@ Once again, the title should concisely explain the change or addition. The descr
 Include any details that add context to the PR, as
 [reviewers likely have less context than you](https://artsy.github.io/blog/2020/08/11/improve-pull-requests-by-including-valuable-context/).
 
-As mentioned above, PRs will be squashed when merged, unless there's a good reason not to (see the [RFC](https://github.com/artsy/README/issues/327)
-that initiated this practice for more explanation and discussion). When they're squashed the title of the PR will
-be used for the single squashed commit, so make sure that you use [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/)
-format in your PR title.
+As mentioned above, PRs will be squashed when merged, unless there's a good reason not to (see the
+[RFC](https://github.com/artsy/README/issues/327) that initiated this practice for more explanation and
+discussion). When they're squashed the title of the PR will be used for the single squashed commit, so make sure
+that you use [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) format in your PR title.
 
 #### Assignees and Reviewers
 

--- a/playbooks/engineer-workflow.md
+++ b/playbooks/engineer-workflow.md
@@ -138,10 +138,8 @@ that you use [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0
 
 #### Assignees and Reviewers
 
-> TLDR; If your PR is ready to be reviewed, be sure to use the `assignee` field to assign it directly to someone;
-> that person will then be ultimately responsible for merging and / or approving (so that you can merge). Folks
-> tagged under the `reviewers` section typically provide feedback, but don’t ultimately merge. However, if the PR
-> is still in progress then one generally adds `WIP` to the title/description and assigns to self.
+> TLDR; If your PR is ready to be reviewed, be sure to use the `assignee` field to indicate who will be responsible
+> for merging. Folks tagged under the `reviewers` section typically provide feedback, but don’t ultimately merge.
 
 **_Request a review_** from at least one team member. This should be someone who has context around the changes
 that were made, experience with the system(s) being modified, and/or knowledge of the language/framework in use.
@@ -155,13 +153,18 @@ Reviewers are asked to leave their review within one business day of being reque
 any reason, it's the reviewer's responsibility to communicate with the author of the PR to establish a different
 timeline or get someone else to review.
 
-**_Assign_** a single team member (they will often also be one of your reviewers) to the PR. This is the person who
-is responsible for moving the PR forward.
+**_Assign_** a single team member to the PR. This is the person who is responsible for moving the PR forward.
 
-Assigning exactly one reviewer - no more and no less - helps ensure that there's no question about who is
-responsible. Since assignees are not explicitly expected to review, it's perfectly fine to both assign and request
-a review from the same person. Once someone has been assigned to a PR, they should make a good faith effort to take
-one of the following actions within one business day:
+If a PR is still in progress and in need of early feedback, then one generally adds `WIP` to the title/description
+and self-assigns.
+
+We encourage you to assign your completed PRs to one of your reviewers in order to maintain momentum and to
+distribute responsibilities and understanding. However self-assigning is permissible when an author wants to retain
+control over merging, sequencing or follow-ups related to the PR.
+
+Assigning exactly one reviewer — no more and no less — helps ensure that there's no question about who is
+responsible. Once someone has been assigned to a PR, they should make a good faith effort to take one of the
+following actions within one business day:
 
 - Merge the PR if comfortable doing so and the criteria below are met,
 - Re-assign to the original author so that they can merge, or

--- a/playbooks/technology_radar/artsy-tech-radar.csv
+++ b/playbooks/technology_radar/artsy-tech-radar.csv
@@ -1,5 +1,4 @@
 name,ring,quadrant,isNew,description
-GraphQL Stitching,hold,techniques,TRUE,"We prefer to connect to upstream REST APIs instead of GraphQL APIs."
 GraphQL,adopt,languages & frameworks,TRUE,"Appreciated for its flexibility and efficiency for clients."
 JSON,adopt,languages & frameworks,FALSE,"We prefer JSON over most other data formats for its self-describing properties."
 Python,adopt,languages & frameworks,FALSE,"For ETL, Analytics and ML workloads we use Python as a data engineering standard."
@@ -56,6 +55,7 @@ Google cloud,hold,platforms,FALSE,
 Heroku,hold,platforms,FALSE,"We prefer kubernetes where we have shared solutions for authorization, logging, monitoring, alerting, scaling, and routing."
 Backends for Frontends,hold,techniques,TRUE,"Rather than tailor backends to particular product surfaces or teams, we strive to serve clients via a unified GraphQL schema, reconciling or disambiguating domain concepts as necessary."
 Bug bounties,hold,techniques,FALSE,
+GraphQL Stitching,hold,techniques,TRUE,"We prefer to connect to upstream REST APIs instead of GraphQL APIs."
 Hypermedia,hold,techniques,FALSE,"While discoverable and easy to consume, we've found hypermedia APIs inefficient to consume."
 Metaphysics' v1 schema,hold,techniques,TRUE,"The v1 schema is deprecated and should be considered frozen. Consumers should switch to v2 rather than make further modifications to v1."
 Serverless architecture,hold,techniques,TRUE,


### PR DESCRIPTION
This is a follow-up to [this Slack discussion](https://artsy.slack.com/archives/C02BC3HEJ/p1684515632728489) in which we noted the need to update guidance around Pull Requests by:

- clarifying some ambiguities
- acknowledging current team practices

(Ignore the reformatting in the first commit; the substantive changes are in 39bfd8b5988423d3022255070784ca44cc6349b2)