### PR TITLE
Add RFC Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/rfc-template.md
+++ b/.github/ISSUE_TEMPLATE/rfc-template.md
@@ -1,0 +1,49 @@
+---
+name: RFC Template
+about: Sample template for how to create a public RFC
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!-- Read the docs about [how to write an RFC at Artsy](https://github.com/artsy/README/blob/43c400d81ff9fee7276c3dd934de26b985da362f/playbooks/rfcs.md) before starting an RFC.
+ -->
+ 
+## Proposal
+
+Apply a spell checker to every markdown document that appears in a PR.
+
+## Reasoning
+
+We want to have polished documents, both internally and externally. Having a spellcheck
+happening without any effort on a developers part means that we'll get a second look at
+any documentation improvements on any repo.
+
+## Exceptions
+
+This won't be perfect, but it is better to get something working than to not have it at all.
+I added the ability to ignore files: so CHANGELOGs which tend to be really jargon heavy will
+be avoided in every repo.
+
+Other than that, we can continue to build up a global list of words to ignore.
+
+## Additional Context
+
+You can see our discussion [in slack here](/link/to/slack.com)
+
+## How is this RFC resolved?
+
+A PR to peril-settings adding the check
+
+<!-- 
+Things to do after you create the RFC: 
+ 
+- Publicise it. Post it on the different slack dev channels, talk about it in meetings, etc.
+- Wait for some time to make sure as many people as possible have seen it and collect feedback
+- Although encouraged, not everyone has to interact. A lack of response is assumed to be positive indifference.
+
+Once the RFC is ready to be resolved, feel free to copy the resolution template that can be found here: https://github.com/artsy/README/blob/43c400d81ff9fee7276c3dd934de26b985da362f/playbooks/rfcs.md#resolution
+
+You can now populate the template and post this as the last comment, if you want also post it on the bottom of RFC description, and finally close the issue.
+-->


### PR DESCRIPTION
Unless I'm missing something our issue template for RFCs does not work anymore. I searched for GH docs and it appears they want these templates in `.github/ISSUE_TEMPLATE/` so I used their builder to create what you see here. I just copy/pasted from the `_templates/rfc.md` file so it should be a match.