### PR TITLE
chore: use danger-github-oss context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
-version: 2
+version: 2.1
 jobs:
   build:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "package.json" }}
-            # fallback to using the latest cache if no exact match is found
+            # Fallback to using the latest cache if no exact match is found
             - v1-dependencies-
 
       - run: yarn install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@
 version: 2
 jobs:
   build:
+    context: danger-github-oss
     docker:
       # specify the version you desire here
       - image: circleci/node:7.10

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@
 version: 2
 jobs:
   build:
-    context: danger-github-oss
     docker:
       # specify the version you desire here
       - image: circleci/node:7.10
@@ -37,3 +36,10 @@ jobs:
       # run tests!
       - run: yarn setup-structure
       - run: yarn danger ci
+
+workflows:
+  default:
+    jobs:
+      - build:
+        context: danger-github-oss
+        name: build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,5 +41,5 @@ workflows:
   default:
     jobs:
       - build:
-        context: danger-github-oss
-        name: build
+          context: danger-github-oss
+          name: build


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PHIRE-82

This switches the CI pipeline to read _danger github token_ from circleci contexts.

Migration: 
- [ ] unset [`DANGER_GITHUB_API_TOKEN` CircleCI project environment variable](https://app.circleci.com/settings/project/github/artsy/README/environment-variables?return-to=https%3A%2F%2Fapp.circleci.com%2Fpipelines%2Fgithub%2Fartsy%2FREADME) before merging
