### PR TITLE
Remove hiring updates from open-standup.md

### DIFF
--- a/events/open-standup.md
+++ b/events/open-standup.md
@@ -42,19 +42,11 @@ Finally, **review this document** for ways to improve the instructions for next 
 ## Our Markdown Template
 
 ```md
-_Welcome new team members!_
-
--
-
 _Props_
 
 -
 
 _Company Updates & Important Communication_
-
--
-
-_Hiring Updates_
 
 -
 


### PR DESCRIPTION
Removing Hiring Updates and Welcoming New Members from the stand-up agenda since we are not hiring extensively now. We could bring them back when needed. Meanwhile, if there are Hiring Updates, we will use the Company Updates section to mention them. 