### PR TITLE
docs(tech-radar): Move Next.js from 'Adopt' to 'Trial'

### DIFF
--- a/playbooks/technology_radar/artsy-tech-radar.csv
+++ b/playbooks/technology_radar/artsy-tech-radar.csv
@@ -1,7 +1,7 @@
 name,ring,quadrant,isNew,description
 GraphQL,adopt,languages & frameworks,TRUE,"Appreciated for its flexibility and efficiency for clients."
 JSON,adopt,languages & frameworks,FALSE,"We prefer JSON over most other data formats for its self-describing properties."
-Next.js,adopt,languages & frameworks,FALSE,"New apps with frontends that are GraphQL centric should use Next. See Forque, Volt 2."
+Next.js,trial,languages & frameworks,FALSE,"Currently trialing Next.js for our admin apps, via the pages router. See Forque, Volt 2. Some experiments have been made to migrate to Next 13's app router, which have all run into friction. See this <a href='https://artsy.slack.com/archives/C2TQ4PT8R/p1697227679293829'>Slack thread for more info</a> "
 Python,adopt,languages & frameworks,FALSE,"For ETL, Analytics and ML workloads we use Python as a data engineering standard."
 Rails,adopt,languages & frameworks,FALSE,
 React Native,adopt,languages & frameworks,FALSE,"New iOS work should use React Native. See also Objective-C."

--- a/playbooks/technology_radar/artsy-tech-radar.csv
+++ b/playbooks/technology_radar/artsy-tech-radar.csv
@@ -1,7 +1,7 @@
 name,ring,quadrant,isNew,description
 GraphQL,adopt,languages & frameworks,TRUE,"Appreciated for its flexibility and efficiency for clients."
 JSON,adopt,languages & frameworks,FALSE,"We prefer JSON over most other data formats for its self-describing properties."
-Next.js,trial,languages & frameworks,FALSE,"Currently trialing Next.js for our admin apps, via the pages router. See Forque, Volt 2. Some experiments have been made to migrate to Next 13's app router, which have all run into friction. See this <a href='https://artsy.slack.com/archives/C2TQ4PT8R/p1697227679293829'>Slack thread for more info</a> "
+Next.js,trial,languages & frameworks,FALSE,"Currently trialing Next.js for our admin apps, via the pages router. See Forque, Volt 2. Some experiments have been made to migrate to Next 13's app router, which have all run into friction. See this <a href='https://artsy.slack.com/archives/C2TQ4PT8R/p1697227679293829'>Slack thread for more info</a>."
 Python,adopt,languages & frameworks,FALSE,"For ETL, Analytics and ML workloads we use Python as a data engineering standard."
 Rails,adopt,languages & frameworks,FALSE,
 React Native,adopt,languages & frameworks,FALSE,"New iOS work should use React Native. See also Objective-C."


### PR DESCRIPTION
Given the most recent attempt to migrate Volt 2 to Next 13's app router, felt we should move this back to Trial. Thoughts on this can be [read in this Slack thread](https://artsy.slack.com/archives/C2TQ4PT8R/p1697227679293829).

TLDR: Next.js pages router works great for us, without gotchas or perceivable problems. Yet, moving to the new app router involves a lot of friction. To recommend Next.js as `Adopt` would, I think, _also_ imply that we're on board with Next.js 13's new router, react server components (RSC) and more. 

As adopting this would come at a significant cost to Artsy due to Palette not being compatible (Palette requires a JS runtime to function), this should give us pause. Moving from `Trial` -> `Adopt` requires more discussion. 