### PR TITLE
doc: link and expand open-source guidelines

### DIFF
--- a/playbooks/documentation.md
+++ b/playbooks/documentation.md
@@ -63,6 +63,7 @@ Content that _maybe_ should be private, depending on its sensitivity:
 - User research or industry analysis that may hold competitive value
 - References to private content (according to the criteria above) including documentation of private systems, links
   to private gists that may include private data or logs, etc.
+- Code repositories that may not be sensitive themselves, but the discussion of which (pull requests, comments, etc.) has a high risk of exposing product plans, customer details, or private data
 
 ## Engineering content _not_ specific to repos
 

--- a/playbooks/open-sourcing.md
+++ b/playbooks/open-sourcing.md
@@ -5,10 +5,7 @@ description: How to take a private repo and make it open-source
 
 # Open-sourcing a project
 
-While we strive for [Open Source by Default](/culture/engineering-principles.md#open-source-by-default), sometimes
-apps start as private repos and only get later open-sourced. This can happen for any number of reasons, such as
-responding to a [nudge](https://github.com/artsy/peril-settings/blob/master/tasks/closedSourceRationaleCheck.ts)
-from Peril.
+While we strive for [Open Source by Default](/culture/engineering-principles.md#open-source-by-default), sometimes apps start as private repos and only get open-sourced later. This can happen based on [our guidelines for public vs. private content](https://github.com/artsy/README/blob/main/playbooks/documentation.md#public-versus-private-content), or even a [nudge](https://github.com/artsy/peril-settings/blob/master/tasks/closedSourceRationaleCheck.ts) from Peril.
 
 Here is a list of things to consider in this situation.
 


### PR DESCRIPTION
Minor additions to:
* Link our open-sourcing playbook to the other playbook's guidelines for public vs. private content
* Mention the additional case that came up with respect to Volt-v2, of code repositories that aren't necessarily sensitive themselves but benefit from the safety of private discussion