### PR TITLE
chore: remove peer learning group section

### DIFF
--- a/events/open-standup.md
+++ b/events/open-standup.md
@@ -74,10 +74,6 @@ _New Milestones / Repos / Blog Posts / Podcast Episodes / New features or update
 
 -
 
-_Peer Learning Group Updates_
-
--
-
 _Knowledge Share_
 
 -


### PR DESCRIPTION
Just keeping our public version of this in sync with [the change](https://artsy.slack.com/archives/C02BC3HEJ/p1711989001006189) we made in Notion