### PR TITLE
chore: update slack reference with recently active channels

### DIFF
--- a/culture/slack.md
+++ b/culture/slack.md
@@ -7,7 +7,7 @@ description: How we use use Slack at Artsy
 
 Get on [Slack](https://artsy.slack.com) 🔒. You can download the OS X app from the
 [Mac App store](https://itunes.apple.com/us/app/slack/id803453959?mt=12). Also, install it on your phone. We use
-Slack for all internal messaging, and prefer it to email in, basically, all cases.
+Slack for all internal messaging, and prefer it to email.
 
 ### Engineering Slack Channels
 
@@ -21,101 +21,48 @@ There are a few other useful dev-related slacks:
 
 - [#dev-help](https://artsy.slack.com/messages/dev-help) 🔒: Get help with any engineering-related questions.
 - [#dev-banter](https://artsy.slack.com/messages/dev-banter) 🔒: For chatting with developers, not about work.
-- [#dev-interviews](https://artsy.slack.com/messages/dev-interviews) 🔒: If you want to get involved in the hiring
-  process.
-- [#dev-ersity](https://artsy.slack.com/messages/dev-ersity) 🔒: If you want to get involved in increasing
-  diversity in engineering.
 
-Engineering teams each maintain a dedicated channel (but all are welcome):
+### Product teams
 
-- Collector Experience:
-  [#product-collector-experience](https://artsy.slack.com/messages/product-collector-experience) 🔒
-- Find & Explore: [#product-find-explore](https://artsy.slack.com/messages/product-find-explore) 🔒
-- Grow: [#product-grow](https://artsy.slack.com/messages/product-grow) 🔒
-- Partner Experience: [#product-partner-experience](https://artsy.slack.com/messages/product-partner-experience) 🔒
-- Velocity (formerly known as Platform): [#product-velocity](https://artsy.slack.com/messages/product-velocity) 🔒
-- Transact: [#product-transact](https://artsy.slack.com/messages/product-transact) 🔒
-
-Some other channels engineers might find helpful:
+Each product team maintains a `#product-<name>` channel which is the primary location for discussion, sharing, and
+decision-making. Join and monitor your team's. Join other teams' channels, too. The more the merrier.
 
 ### Practices
+
+Practices are informal groups of engineers working on similar problems.
 
 - [#practice-web](https://artsy.slack.com/messages/practice-web) 🔒
 - [#practice-mobile](https://artsy.slack.com/messages/practice-mobile) 🔒
 - [#practice-platform](https://artsy.slack.com/messages/practice-platform) 🔒
-- [#practice-data](https://artsy.slack.com/messages/practice-data) 🔒
 
 ### Incident Handling
 
 - [#alerts](https://artsy.slack.com/messages/alerts)🔒: automated system alerts
 - [#incidents](https://artsy.slack.com/messages/alerts)🔒: Any incident-handling starts (as a thread) here.
+- Dedicated channels are created to handle most incidents.
 
-### Misc
+### Miscellaneous
 
-- [#deployments](https://artsy.slack.com/messages/deployments) 🔒
-- [#elixir](https://artsy.slack.com/messages/elixir) 🔒
-- [#global](https://artsy.slack.com/messages/global) 🔒
+There are _many_ other topic-specific channels. You'll find these out organically, but here are a few:
+
+- [#ai](https://artsy.slack.com/messages/ai) 🔒
 - [#dev-graphql](https://artsy.slack.com/messages/dev-graphql) 🔒
-- [#onboarding-eng](https://artsy.slack.com/messages/onboarding-eng) 🔒
+- [#dev-ruby](https://artsy.slack.com/messages/dev-ruby) 🔒
+- [#dev-knowledge-share](https://artsy.slack.com/messages/dev-knowledge-share) 🔒
 - [#peopleops](https://artsy.slack.com/messages/peopleops) 🔒
-- [#product](https://artsy.slack.com/messages/product) 🔒
 - [#workplace](https://artsy.slack.com/messages/workplace) 🔒
-
-There are _many_ other topic-specific channels. You'll find these out organically. Here is a sample list of
-interesting, [banter-y Slack channels](https://artsy.slack.com/archives/C02531TUD/p1533749286000516) 🔒 you might
-want to check out:
-
-- [#cabort-bookclub](https://artsy.slack.com/messages/cabort-bookclub) 🔒 is a sci-fi book club
-- [#video-games](https://artsy.slack.com/messages/video-games) 🔒 for video games
 - [#cats](https://artsy.slack.com/messages/cats) 🔒 for cat-lovers
 - [#dogs](https://artsy.slack.com/messages/dogs) 🔒 for dog-lovers
-- [#teamcanada](https://artsy.slack.com/messages/teamcanada) 🔒 for Canadians and Canadian-adjacent people
-- [#hotpot](https://artsy.slack.com/messages/hotpot) 🔒 for organizing hotpot dinners in Chinatown, next door to
-  the office
-- [#vr](https://artsy.slack.com/messages/vr) 🔒 for virtual reality
 - [#aotd](https://artsy.slack.com/messages/aotd) 🔒 is "Artwork of the Day", a good place to chat about art
-- [#extreme-bevvies](https://artsy.slack.com/messages/extreme-bevvies) 🔒 is for extreme beverages (started with
-  Soylent but has evolved a lot since)
-- [#house-plants](https://artsy.slack.com/messages/house-plants) 🔒 for house plants (conversations, questions,
-  asking for help)
-- [#karaoke](https://artsy.slack.com/messages/karaoke) 🔒 for organizing karaoke outings
-- [#samplesales](https://artsy.slack.com/messages/sameplsales) 🔒 to coordinate around sample sales, a staple of
-  NYC and of Tribeca particularly
-- [#android](https://artsy.slack.com/messages/android) 🔒 for Android-lovers
-- [#anime](https://artsy.slack.com/messages/anime) 🔒 for anime-lovers
 - [#yelling](https://artsy.slack.com/messages/yelling) 🔒 is a CAPS-ONLY channel
-- [#coffeetalk](https://artsy.slack.com/messages/coffeetalk) 🔒 for chat about coffee
-- [#jam-session](https://artsy.slack.com/messages/jam-session) 🔒 for musicians at Artsy to plan monthly after-work
-  jam-sessions
-- [#productivity-tips](https://artsy.slack.com/messages/productivity-tips) 🔒 for random things that make you more
-  productive
-- [#postcards](https://artsy.slack.com/messages/postcards) 🔒 for the love of postcards
 
-### Tips and Tricks
+### Tips
 
-- Typing `@channel` in any channel will send a notification to everyone in that channel. Refrain from doing this
-  unless it’s imperative that everyone see your message. You can also `@` people directly in a channel, or
-  direct-message them.
-
-- If it's relevant to people in the room at the moment, use `@here`.
-
-- Most sets of people are set up as a slack team, `@dev-leads`, `@engineering`, `@dteam` (design), `@mobile` and
-  `@product-managers`. Feel free to make more.
-
-- `/call` or `/hangout` will start a video chat in that channel.
-
-- Slack uses markdown for styling text.
-
-  - \`\`\``multi-line code`\`\`\`
-  - \``single-line code`\`
-  - \*_italic_\*
-  - \*\***bold**\*\*
-
+- _Thread_ related conversations to limit channel noise.
+- Mentioning `@channel` will notify everyone in the channel. Mentioning `@here` will notify those currently active
+  in the channel. Use both with caution.
 - Read this short article on
   [getting the most out of Slack](https://slackhq.com/11-useful-tips-for-getting-the-most-of-slack).
-
+- [Organize your slack sidebar into custom sections](https://slack.com/help/articles/360043207674-Organize-your-sidebar-with-custom-sections)
+  (like teams, collaborators, incidents, and practices).
 - Please don't swear.
-
-### Bots
-
-We have a lot of them, too many in fact to keep this doc up to date.


### PR DESCRIPTION
* Remove channels that are archived or haven't been active for a while.
* Add a few channels that have been active recently.
* Refresh tips.
* Shorten, slightly.