### PR TITLE
RFC: disclose LLM usage in commits or PRs

### DIFF
--- a/playbooks/engineer-workflow.md
+++ b/playbooks/engineer-workflow.md
@@ -81,6 +81,17 @@ Include any details that add context to the PR, as [reviewers likely have less c
 
 If for any reason a PR doesn't contain well-structured commits, [title the PR using the conventional commit format](https://github.com/artsy/README/issues/327) and recommend that it be squashed into `main` rather than merged.
 
+#### Co-authors
+
+It's nice to give credit for pairing by [specifying co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in commits and PRs.
+
+When an LLM has materially contributed to a change, our convention is to specify that in an annotation as well. E.g.:
+
+```
+Co-authored-by: Jane McJaneson <jane@artnet.com>
+Co-authored-by: Cursor (claude-sonnet-4-6) <noreply@cursor.sh>
+```
+
 #### Assignees and Reviewers
 
 **Request a review** from at least one team member. This should be someone who has context around the changes that were made, experience with the system(s) being modified, and/or knowledge of the language/framework in use. Feedback is always welcome from team members not specifically requested as well.

--- a/playbooks/engineer-workflow.md
+++ b/playbooks/engineer-workflow.md
@@ -81,15 +81,15 @@ Include any details that add context to the PR, as [reviewers likely have less c
 
 If for any reason a PR doesn't contain well-structured commits, [title the PR using the conventional commit format](https://github.com/artsy/README/issues/327) and recommend that it be squashed into `main` rather than merged.
 
-#### Co-authors
+#### Trailers
 
 It's nice to give credit for pairing by [specifying co-authors](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in commits and PRs.
 
-When an LLM has materially contributed to a change, our convention is to specify that in an annotation as well. E.g.:
+When an LLM has materially contributed to a change, our convention is to specify that in an `Assisted-by` annotation as well. E.g.:
 
 ```
 Co-authored-by: Jane McJaneson <jane@artnet.com>
-Co-authored-by: Cursor (claude-sonnet-4-6) <noreply@cursor.sh>
+Assisted-by: Claude:Opus-4.5
 ```
 
 #### Assignees and Reviewers


### PR DESCRIPTION
## Summary

Adopt a lightweight convention for marking commits and/or PRs that were produced with significant assistance from an LLM, including which provider and--optionally--model.

## Proposal

Engineers should annotate commits or PRs where an LLM materially contributed to the change, using the [emerging](https://allthingsopen.org/articles/open-source-ai-contributions-assisted-by-git-trailer-standard) `Assisted-by` git trailer convention. Model and version are helpful but optional. E.g.:

```
Assisted-by: Claude:Opus-4.5
```

<details>
  <summary>Original proposal</summary>
Engineers should annotate commits or PRs where an LLM materially contributed to the change, using git's existing `Co-authored-by` pattern. Model and version are helpful but optional. Examples:

```
Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>
```

```
Co-authored-by: GitHub Copilot <noreply@github.com>
```

```
Co-authored-by: Jane McJaneson <jane@artnet.com>
Co-authored-by: Cursor (claude-sonnet-4-6) <noreply@cursor.sh>
```
</details>

## Reasoning

This creates transparency and maybe even a queryable record of AI involvement in our codebase. LLM-assisted development is already routine, but we have limited visibility into which changes were AI-assisted and which tool or model produced them. Without that signal we cannot:

- Measure the volume and trajectory of AI-assisted contributions across teams and repos
- Correlate AI authorship with downstream signals: release frequency, review latency, defect/rework rates, test coverage changes, incidents, etc.
- Tune our policies (code review, test coverage, security scanning, CI workflows, release gates...) based on real-world experience

## Exceptions

- Not a disclaimer or warning label. AI-assisted code is held to the same standard as any other code. I.e., authors, reviewers, and ultimately teams are fully responsible.
- Not enforced or verified. We don't intend to use this for legal, licensing, or provenance purposes.
- Obviously we're not concerned with past commits or PRs, only future ones.

## Additional Context

~Tools like Claude Code already emit this by default, so the additional lift for users of other tools (or Claude Code users who hand-author commits or PRs) is minimal. Github already renders these coauthors faithfully in its UI and parses them for stats.~ Multiple co-authors are already supported.

Both Artsy and Artnet have adopted conventional commits as a way to structure commit and PR messages. Tools can ostensibly parse this data, and we've analyzed that to understand trends in the past (though the necessary data integrations were disabled during recent migrations). We don't want to constrain engineers, but do want to be able to ask questions about the results in the future. This starts to give us some data to work with.

_Related:_ [EFF's recent policy](https://www.eff.org/about/opportunities/volunteer/coding-with-eff) about disclosing AI involvement in PRs to their open-source projects

## How is this RFC resolved?

I'll leave this open for at least a week for discussion. I'd especially like feedback about:
* Is this too burdensome?
* Are there other formal ways we should consider annotating PRs?


