### PR TITLE
docs: Retire the Tech Lead role from the engineering ladder and onboarding docs

### DIFF
--- a/careers/ladder.md
+++ b/careers/ladder.md
@@ -5,19 +5,13 @@ description: Career development at Artsy
 
 # Engineering Ladder
 
-This documents Artsy's Engineering Ladder, a framework to help evaluate performance, goals, and compensation for
-engineers at Artsy. It is synced up with the Artsy
-[company-wide framework 🔑](https://docs.google.com/spreadsheets/d/1rw7wEUvigrD_0Vb50Bzz35BQxo58tFwHhDJAS7v5pLU/edit?gid=1253823157#gid=1253823157)
-for levels and titles.
+This documents Artsy's Engineering Ladder, a framework to help evaluate performance, goals, and compensation for engineers at Artsy. It is synced up with the Artsy [company-wide framework 🔑](https://docs.google.com/spreadsheets/d/1rw7wEUvigrD_0Vb50Bzz35BQxo58tFwHhDJAS7v5pLU/edit?gid=1253823157#gid=1253823157) for levels and titles.
 
-This document is open and evolving. We encourage you to submit issues or start an RFC to suggest changes and ensure
-our framework is doing the best it can to help Artsy fairly evaluate compensation and career growth for engineers.
+This document is open and evolving. We encourage you to submit issues or start an RFC to suggest changes and ensure our framework is doing the best it can to help Artsy fairly evaluate compensation and career growth for engineers.
 
 ## Tracks
 
-The Engineering Ladder encapsulates two tracks—an individual contributor (IC2–IC8) and manager track (M2–M6). The
-manager track is available to engineers who have achieved an "IC5 Senior Engineer" level on the individual
-contributor ladder.
+The Engineering Ladder encapsulates two tracks—an individual contributor (IC2–IC8) and manager track (M2–M6). The manager track is available to engineers who have achieved an "IC5 Senior Engineer" level on the individual contributor ladder.
 
 | Individual Contributor | Artsy IC Level | Artsy M Level | Manager                        |
 | ---------------------- | -------------- | ------------- | ------------------------------ |
@@ -32,12 +26,9 @@ contributor ladder.
 
 ## Individual Contributors
 
-Individual contributor engineers define a "maker" role at Artsy where a person is responsible for writing code on a
-regular basis and has no direct reports. As an individual contributor engineer grows at Artsy the scale and impact
-of the code they write and systems they maintain is expected to increase.
+Individual contributor engineers define a "maker" role at Artsy where a person is responsible for writing code on a regular basis and has no direct reports. As an individual contributor engineer grows at Artsy the scale and impact of the code they write and systems they maintain is expected to increase.
 
-From one level to another, the scope of direct impact gradually increases and so does the sphere of influence.
-Increased mastery is a necessary condition but isn't sufficient to expand impact.
+From one level to another, the scope of direct impact gradually increases and so does the sphere of influence. Increased mastery is a necessary condition but isn't sufficient to expand impact.
 
 ```
 Scope of impact:     Self     >        Team          >  Teams  > Org
@@ -50,18 +41,13 @@ Level          : Eng 1, Eng 2 > Sen Eng 1, Sen Eng 2 >  Staff  > Sen Staff+
   - TODO: This level still needs to be added to the ladder.
 - Engineer 1 (IC2): Focuses on being an effective individual contributor.
 - Engineer 2 (IC3): Is an effective team member.
-- Senior Engineer 1 (IC4): Consistently drives change and impact across a significant portion of their product
-  team.
+- Senior Engineer 1 (IC4): Consistently drives change and impact across a significant portion of their product team.
 - Senior Engineer 2 (IC5): Consistently drives change and impact across their whole product team.
 - Staff Engineer (IC6): can drive change and impact across multiple teams.
-- Senior Staff Engineer (IC7): can drive change and impact across full Product, Data, Design and Engineering
-  organization
+- Senior Staff Engineer (IC7): can drive change and impact across full Product, Data, Design and Engineering organization
   - TODO: This level still needs to be added to the ladder.
 
-_Note: This ladder is heavily inspired by
-[Better's Technical Career Ladder](https://better.engineering/technical-career-ladder/) and
-[Rent the Runway's Engineering Ladder](https://dresscode.renttherunway.com/blog/ladder), which we believe have the
-appropriate levels of specificity to enable meaningful career development conversations._
+_Note: This ladder is heavily inspired by [Better's Technical Career Ladder](https://better.engineering/technical-career-ladder/) and [Rent the Runway's Engineering Ladder](https://dresscode.renttherunway.com/blog/ladder), which we believe have the appropriate levels of specificity to enable meaningful career development conversations._
 
 ### Evaluation criteria
 
@@ -80,23 +66,11 @@ appropriate levels of specificity to enable meaningful career development conver
 
 ### Bragging Document
 
-It can be helpful to maintain a bragging document to really understand the ladder and also to get your work
-recognized. Julia Evans has put it really well in her [blog post](https://jvns.ca/blog/brag-documents/) explaining
-that neither you nor your manager will remember everything you did. To help you track your work and also get
-alignment with your manager on where you are standing in terms of performance you can use this
-[template](https://docs.google.com/spreadsheets/d/1yPZeLhkFjlEMUfstDvOXxQXLqBKmr-I-xD0uUwdO2Zc/edit#gid=0) as a
-base for your bragging. It also contains some real world bragging examples of fellow Artsy engineers.
+It can be helpful to maintain a bragging document to really understand the ladder and also to get your work recognized. Julia Evans has put it really well in her [blog post](https://jvns.ca/blog/brag-documents/) explaining that neither you nor your manager will remember everything you did. To help you track your work and also get alignment with your manager on where you are standing in terms of performance you can use this [template](https://docs.google.com/spreadsheets/d/1yPZeLhkFjlEMUfstDvOXxQXLqBKmr-I-xD0uUwdO2Zc/edit#gid=0) as a base for your bragging. It also contains some real world bragging examples of fellow Artsy engineers.
 
 ### Visualisation
 
-To help with the visualisation of the ladder we have created this visual, inspired by
-[honeycomb.io](https://www.honeycomb.io/blog/engineering-levels-at-honeycomb/). It is not perfect but it allows for
-a quick overview of the levels in terms of impact as well as ownership. We wanted to show that each level
-encompasses the previous levels and there is flexibility in how to interpret and operate on each level based on
-individual interests. As mentioned in the linked article "...someone might operate at a higher level of ownership
-in a smaller scope or at a smaller level of ownership at a larger scope, or somewhere in between. Of course, there
-is value in growing in both dimensions, but it is more common to stretch in one direction or the other at any given
-point."
+To help with the visualisation of the ladder we have created this visual, inspired by [honeycomb.io](https://www.honeycomb.io/blog/engineering-levels-at-honeycomb/). It is not perfect but it allows for a quick overview of the levels in terms of impact as well as ownership. We wanted to show that each level encompasses the previous levels and there is flexibility in how to interpret and operate on each level based on individual interests. As mentioned in the linked article "...someone might operate at a higher level of ownership in a smaller scope or at a smaller level of ownership at a larger scope, or somewhere in between. Of course, there is value in growing in both dimensions, but it is more common to stretch in one direction or the other at any given point."
 
 <img src="./images/artsy-career-ladder.png" width="600" title="Artsy career ladder visualisation" alt="Artsy career ladder visualisation">
 
@@ -270,7 +244,7 @@ point."
         <ul>
           <li>Translate product/design specs into technical tasks that can be efficiently worked on by the members of the team and make sure team members understand the context behind what they will be building.</li>
           <li>Brings ideas to the PM and is trusted as someone who can run with and stake out bigger projects.</li>
-          <li>When need be, can take on Tech Lead responsibilities or lead a key project.</li>
+          <li>Steps up as a Project Lead for key initiatives and can coordinate workstreams across the team.</li>
           <li>Often has conversations with the PM about improvements to the product or infrastructure, occasionally comes up with completely new ideas.</li>
         </ul>
       </td>
@@ -537,7 +511,7 @@ point."
         <ul>
           <li>Sets the agenda during 1:1s with their manager.</li>
           <li>Proactively raises issues and obstacles to their manager.</li>
-          <li>Works closely with tech lead, team mates, mentor to get unblocked.</li>
+          <li>Works closely with team mates, mentor to get unblocked.</li>
         </ul>
       </td>
       <td>
@@ -565,45 +539,16 @@ point."
   </tbody>
 </table>
 
-## Technical Leads
-
-Every team at Artsy has a Technical Lead who is part of the Core Team (Product Manager, Technical Lead, Data
-Analyst, Product Designer and Engineering Manager). The Technical Lead's key responsibilities are:
-
-- Partnering closely with the rest of the Core Team to jointly lead the team and deliver business value effectively
-  (including proactively defining team strategy, roadmap, project scoping and milestone definitions, etc.)
-- Driving the team's technology choices and aligning their decisions with the rest of the Engineering organization
-- Ensuring successful project delivery.
-
-Taking on a Technical Lead role is a great opportunity for someone to expand their impact (including to expand
-scope, to achieve team wide impact, or to pave the way towards an Engineering Management career). Throughout their
-career, an Individual Contributor or an Engineering Manager may swap in and out of this Technical Lead role.
-
-See
-[this document](https://www.notion.so/artsy/Artsy-Tech-Lead-Expanded-Responsibilities-Public-710ee0cd2fce47dcaa722ece80e365b2)
-for an expanded set of Tech Lead Responsibilities at Artsy.
-
 ## Engineering Management
 
-A manager’s role at Artsy balances people management responsibilities with team delivery responsibilities. As a
-people manager, they are responsible for hiring, retaining, growing and managing the performance of their reports.
-Additionally, they're expected to significantly impact teams' success through their own technical contribution
-and/or delivery management. Delivery management is broadly defined here as any non-coding activity that will help
-the team ship faster, with better quality, and with increased impact (for instance: improving team processes,
-mitigating risks around release planning, facilitating internal and external communication). As an engineering
-manager grows at Artsy, their scope of impact will increase from one team to multiple teams and from managing ICs
-to managing ICs and other EMs.
+A manager’s role at Artsy balances people management responsibilities with team delivery responsibilities. As a people manager, they are responsible for hiring, retaining, growing and managing the performance of their reports. Additionally, they're expected to significantly impact teams' success through their own technical contribution and/or delivery management. Delivery management is broadly defined here as any non-coding activity that will help the team ship faster, with better quality, and with increased impact (for instance: improving team processes, mitigating risks around release planning, facilitating internal and external communication). As an engineering manager grows at Artsy, their scope of impact will increase from one team to multiple teams and from managing ICs to managing ICs and other EMs.
 
 ### tl;dr
 
-- Engineering Manager 1: Transitional from an Individual Contributor role, the main focus is learn how to manage
-  people.
-- Engineering Manager 2: Proficient at managing 6+ Individual Contributors and act as a delivery multiplier on
-  their team.
-- Senior Engineering Manager: Has meaningful delivery impact across multiple teams and starts having engineering
-  org wide impact, can start learning how to manage managers.
-- Director of Engineering: Proficient at managing Engineering Managers and has consistent engineering org wide
-  impact.
+- Engineering Manager 1: Transitional from an Individual Contributor role, the main focus is learn how to manage people.
+- Engineering Manager 2: Proficient at managing 6+ Individual Contributors and act as a delivery multiplier on their team.
+- Senior Engineering Manager: Has meaningful delivery impact across multiple teams and starts having engineering org wide impact, can start learning how to manage managers.
+- Director of Engineering: Proficient at managing Engineering Managers and has consistent engineering org wide impact.
 - Senior Director of Engineering: Has consistent company wide impact.
 
 ### Evaluation criteria
@@ -656,7 +601,7 @@ to managing ICs and other EMs.
       <td class="border-top">
         <ul>
           <li>Builds strong ties to the rest of the engineering manager community and activity participates in manager-wide forums.</li>
-          <li>Knows how to get high quality feedback from PMs, TLs and other members of their reports' teams.</li>
+          <li>Knows how to get high quality feedback from PMs and other members of their reports' teams.</li>
           <li>Identifies team staffing needs.</li>
         </ul>
       </td>
@@ -685,7 +630,7 @@ to managing ICs and other EMs.
           <li>Works closely with the team to meet the sprint goals; significantly accelerates the delivery and increases the impact of the team throughout the quarter.</li>
           <li>Effectively addresses team health issues both in their own and their reports' teams when need be.</li>
           <li>Leads some engineering wide improvements.</li>
-          <li>Partners effectively with the tech lead (and the core team) to get their team to a higher performing state.</li>
+          <li>Partners effectively with the core team to get their team to a higher performing state.</li>
         </ul>
       </td>
       <td class="border-top">
@@ -712,7 +657,7 @@ to managing ICs and other EMs.
           <li>Optimizes Eng IC hiring at scale and across pipelines.</li>
           <li>Starts managing Engineering Managers.</li>
           <li>Can own a EM hiring pipeline with support from their manager.</li>
-          <li>Can grow Tech Leads to have a multiplier effect on their team.</li>
+          <li>Can grow senior and staff engineers to have a multiplier effect on their team.</li>
         </ul>
       </td>
       <td class="border-top">
@@ -726,7 +671,7 @@ to managing ICs and other EMs.
       <td class="border-top">
         <ul>
           <li>Develops strong collaboration with PDDE Leadership team members.</li>
-          <li>Can successfully influence XFN partners to drive improvements across teams (and even more so the Tech Leads).</li>
+          <li>Can successfully influence XFN partners and senior engineers to drive improvements across teams.</li>
           <li>Suggest optimal resource allocation given business goals and constraints.</li>
           <li>Knows how to combine technical guidance, delivery management and coaching to increase teams' impact.</li>
           <li>Proactively identifies issues across multiple teams and effectively addresses them.</li>
@@ -745,7 +690,7 @@ to managing ICs and other EMs.
         <ul>
           <li>Manage and coach Engineering Managers to be effective communicators and managers of their people.</li>
           <li>Can drive and improve EM hiring pipeline.</li>
-          <li>Ensures that EMs and TLs are mentoring and managing teams effectively towards results.</li>
+          <li>Ensures that EMs are mentoring and managing teams effectively towards results.</li>
         </ul>
       </td>
       <td class="border-top">
@@ -780,7 +725,7 @@ to managing ICs and other EMs.
           <li>Can manage Directors as well as EMs.</li>
           <li>Can drive Director hiring pipeline.</li>
           <li>Grows engineering leaders.</li>
-          <li>Provides the right balance of direction and empowerment so EMs, TLs, and teams make decisions that are aligned with the company and engineering strategy and goals.</li>
+          <li>Provides the right balance of direction and empowerment so EMs and teams make decisions that are aligned with the company and engineering strategy and goals.</li>
         </ul>
       </td>
       <td class="border-top">

--- a/onboarding/managers.md
+++ b/onboarding/managers.md
@@ -7,7 +7,7 @@ description: Things for managers to remember during the early days of onboarding
 
 ### Before Day 1
 
-- [ ] Choose an [onboarding mentor](/onboarding/mentors.md#the-onboarding-mentor) for the new hire. 
+- [ ] Choose an [onboarding mentor](/onboarding/mentors.md#the-onboarding-mentor) for the new hire.
 - [ ] Create [an onboarding github issue](https://github.com/artsy/potential/issues/new?template=engineering-onboarding.md) 🔒 based on the onboarding template. Tag the onboarding mentor and label the issue as `onboarding`. Also invite the team to say hi, as this is a place that the new hire should always be able to find easily in the future.
 - [ ] Set first-week schedule
 - [ ] Invite new hire to all engineering-wide meetings
@@ -30,10 +30,10 @@ description: Things for managers to remember during the early days of onboarding
 
 ### And onward!
 
-- [ ] When the new hire is assigned to an initial product team, work with the PM/tech lead of that team to make sure they are set up and invited to all relevant meetings.
-- [ ] Remind tech leads/PMs/EMs that are part of the sprint rotation to prepare resources and invite new hire to meetings
+- [ ] When the new hire is assigned to an initial product team, work with the PM of that team to make sure they are set up and invited to all relevant meetings.
+- [ ] Remind PMs/EMs that are part of the sprint rotation to prepare resources and invite new hire to meetings
 
 ## Onboarding New Managers
 
 - [ ] Invite to meetings relevant to managers.
-- [ ] Remind tech-leads/PMs that the new manager’s main objective is to get to meet and work with everybody. As such they should be given diverse tasks and e.g. coupled with various engineers for pairing sessions, as well as leaving them with time to have 1:1s with all the engineers (including tech-lead), PM, and designer.
+- [ ] Remind PMs that the new manager’s main objective is to get to meet and work with everybody. As such they should be given diverse tasks and e.g. coupled with various engineers for pairing sessions, as well as leaving them with time to have 1:1s with all the engineers, PM, and designer.

--- a/onboarding/mentors.md
+++ b/onboarding/mentors.md
@@ -23,7 +23,7 @@ Each new engineering hire is assigned an _Onboarding mentor_ by their manager. O
 
 ### How to be an onboarding mentor
 
-The role of a mentor is purposely different from that of a manager or technical lead, and that role shifts to accommodate the needs of a team member. It's up to the mentoring pair to find what works best for them and to ensure the relationship evolves over time to remain useful.
+The role of a mentor is purposely different from that of a manager, and that role shifts to accommodate the needs of a team member. It's up to the mentoring pair to find what works best for them and to ensure the relationship evolves over time to remain useful.
 
 #### What to do?
 

--- a/playbooks/engineer-workflow.md
+++ b/playbooks/engineer-workflow.md
@@ -12,6 +12,7 @@ description: How we work together
     - [Working in branches](#working-in-branches)
     - [Commit Messages](#commit-messages)
     - [Pull requests](#pull-requests)
+      - [Trailers](#trailers)
       - [Assignees and Reviewers](#assignees-and-reviewers)
       - [Sequencing](#sequencing)
     - [Code Reviews](#code-reviews)

--- a/playbooks/technical-planning.md
+++ b/playbooks/technical-planning.md
@@ -14,25 +14,20 @@ Technical planning is a crucial part of our engineering process. Writing tech pl
 - Get feedback early on in the development process, to avoid costly U-turns further down the line.
 - Refine and shape product requirements.
 
-Developers should use their judgment when deciding whether or not to write a tech plan, but we recommend them when
-planning:
+Developers should use their judgment when deciding whether or not to write a tech plan, but we recommend them when planning:
 
 1. Technical design for medium to large features
 1. Architectural changes or new design patterns
 1. Changes affecting other teams' products or engineers' workflows
 1. New integrations or services
 
-If the feature you're working on follows our established patterns, or the design and discussion can fit equally
-well within a PR, it's OK to skip.
+If the feature you're working on follows our established patterns, or the design and discussion can fit equally well within a PR, it's OK to skip.
 
 ## Tech Plans vs. Product Briefs
 
-Technical plans discuss and propose a technical implementation, while product briefs should govern the design, user
-experience, and business requirements of a feature. We recommend linking to an associated product brief for
-context, but product and requirement decisions should live on the product brief, not on the tech plan.
+Technical plans discuss and propose a technical implementation, while product briefs should govern the design, user experience, and business requirements of a feature. We recommend linking to an associated product brief for context, but product and requirement decisions should live on the product brief, not on the tech plan.
 
-It's natural to discover new product implications through the tech planning process. If this happens, make sure
-those discussions are routed to the product brief for clarity.
+It's natural to discover new product implications through the tech planning process. If this happens, make sure those discussions are routed to the product brief for clarity.
 
 ## Tech Plan States
 
@@ -44,58 +39,39 @@ those discussions are routed to the product brief for clarity.
 
 ## Writing a tech plan
 
-Follow the template in Notion, but feel free to add or skip sections. If the technical plan involves a notable
-technical decision, we recommend briefly describing the alternatives considered. A
-[decision matrix](https://review.firstround.com/this-matrix-helps-growing-teams-make-great-decisions) can help with
-their evaluation
-([example here](https://www.notion.so/artsy/d17290484e6b40ac9e871eb7070dd3e8?v=81f6f3bf425b43e48fadd3c36adc2e09)).
+Follow the template in Notion, but feel free to add or skip sections. If the technical plan involves a notable technical decision, we recommend briefly describing the alternatives considered. A [decision matrix](https://review.firstround.com/this-matrix-helps-growing-teams-make-great-decisions) can help with their evaluation ([example here](https://www.notion.so/artsy/d17290484e6b40ac9e871eb7070dd3e8?v=81f6f3bf425b43e48fadd3c36adc2e09)).
 
 ## Reviewers
 
-Choose appropriate reviewers who can best evaluate your plan's approach, similar to Github PR reviewers. Some
-guidelines:
+Choose appropriate reviewers who can best evaluate your plan's approach, similar to Github PR reviewers. Some guidelines:
 
 - Aim for ~3-5 reviewers.
-- Reviewers should be engineers given the tech plan is focused on implementation. Input from outside engineering is
-  always welcome.
-- Seek out the most critical review, to ensure the best decision. E.g., if the change affects another team's
-  domain, include someone from that team. Consider including your team's tech lead as well as relevant staff
-  engineers.
+- Reviewers should be engineers given the tech plan is focused on implementation. Input from outside engineering is always welcome.
+- Seek out the most critical review, to ensure the best decision. E.g., if the change affects another team's domain, include someone from that team. Consider including relevant senior and staff engineers from your team.
 
 If you are not initially a reviewer but have blocking feedback, you may add yourself as a reviewer.
 
 ## Receiving Feedback
 
-Since all developers are invited to participate on a tech plan and leave feedback, setting clear expectations on
-the tech plan's timeline can help ensure this process is smooth. We recommend filling out the "Feedback requested
-by" date field.
+Since all developers are invited to participate on a tech plan and leave feedback, setting clear expectations on the tech plan's timeline can help ensure this process is smooth. We recommend filling out the "Feedback requested by" date field.
 
-If there is someone that you explicitly want feedback from, include them in the Stakeholders section (and don't
-hesitate to remind them directly).
+If there is someone that you explicitly want feedback from, include them in the Stakeholders section (and don't hesitate to remind them directly).
 
-Significant tech plans benefit from a synchronous review in a practice meeting. If there is not a practice meeting
-that works for your timeline, schedule something ad-hoc. Make sure to mention the tech plan in
-[our weekly engineering standup](https://github.com/artsy/README/blob/main/events/open-standup.md) to invite
-broader feedback.
+Significant tech plans benefit from a synchronous review in a practice meeting. If there is not a practice meeting that works for your timeline, schedule something ad-hoc. Make sure to mention the tech plan in [our weekly engineering standup](https://github.com/artsy/README/blob/main/events/open-standup.md) to invite broader feedback.
 
 ## Giving Tech Plan Feedback
 
-Feedback is expected and encouraged. Similar to leaving PR comments, please distinguish between blocking and
-non-blocking feedback so that your intent is clear.
+Feedback is expected and encouraged. Similar to leaving PR comments, please distinguish between blocking and non-blocking feedback so that your intent is clear.
 
-If you have questions about or significant feedback on the overall direction of the tech plan, we recommend asking
-the tech plan author to hop on a quick call to discuss.
+If you have questions about or significant feedback on the overall direction of the tech plan, we recommend asking the tech plan author to hop on a quick call to discuss.
 
 ## Reviewing and Approving a Tech Plan
 
-Stakeholders are required to formally review the tech plan (also in a similar manner as Github PRs) by marking the
-plan with the appropriate review status:
+Stakeholders are required to formally review the tech plan (also in a similar manner as Github PRs) by marking the plan with the appropriate review status:
 
 - **Approved** means that you are OK with the direction proposed by the plan.
-- **Request changes** means that you require some changes (that you clarify in the Comments section) before
-  accepting the plan.
+- **Request changes** means that you require some changes (that you clarify in the Comments section) before accepting the plan.
 
 Based on these review statuses, the tech plan author can make changes and ask for a subsequent review.
 
-While the tech plan writer is responsible for the ultimate decision on whether a tech plan moves into the next
-state, they are expected to seek and take feedback from reviewers seriously and address requested changes.
+While the tech plan writer is responsible for the ultimate decision on whether a tech plan moves into the next state, they are expected to seek and take feedback from reviewers seriously and address requested changes.


### PR DESCRIPTION
Following the decision to retire the Tech Lead role at Artsy (only two teams still operated with a TL), this PR removes references to the TL role from the engineering ladder, onboarding playbooks, and related docs.

## Changes

- `careers/ladder.md`: removes the "Technical Leads" section and rewrites inline TL references in the IC and Engineering Manager ladder rows.
- `onboarding/managers.md`: removes TL mentions from new-hire and new-manager onboarding checklists.
- `onboarding/mentors.md`: drops the TL reference when contrasting the mentor role.
- `playbooks/technical-planning.md`: replaces the TL reviewer suggestion with senior/staff engineers.

> [!NOTE]
> The pre-commit hook (prettier) reflowed some long markdown lines in the touched files, so the diff includes formatting-only changes alongside the content edits.

🤖 Created with Claude Code

@artsy/engineering-managers 